### PR TITLE
[ADD] : UsersProfile Entity 추가

### DIFF
--- a/src/main/java/com/backend/naildp/common/ProfileType.java
+++ b/src/main/java/com/backend/naildp/common/ProfileType.java
@@ -1,0 +1,7 @@
+package com.backend.naildp.common;
+
+public enum ProfileType {
+
+	BASIC, ICON, CUSTOMIZATION
+
+}

--- a/src/main/java/com/backend/naildp/controller/UserInfoController.java
+++ b/src/main/java/com/backend/naildp/controller/UserInfoController.java
@@ -1,5 +1,7 @@
 package com.backend.naildp.controller;
 
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,4 +30,14 @@ public class UserInfoController {
 		return ResponseEntity.ok(ApiResponse.successResponse(userInfoResponseDto, "사용자 정보 조회 성공", 2000));
 
 	}
+
+	@GetMapping("/point")
+	ResponseEntity<ApiResponse<?>> getPoint(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+		Map<String, Object> point = userInfoService.getPoint(userDetails.getUser().getNickname());
+
+		return ResponseEntity.ok(ApiResponse.successResponse(point, "포인트 조회 성공", 2000));
+
+	}
+
 }

--- a/src/main/java/com/backend/naildp/controller/UserInfoController.java
+++ b/src/main/java/com/backend/naildp/controller/UserInfoController.java
@@ -5,8 +5,11 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.backend.naildp.dto.userInfo.UserInfoResponseDto;
 import com.backend.naildp.exception.ApiResponse;
@@ -38,6 +41,15 @@ public class UserInfoController {
 
 		return ResponseEntity.ok(ApiResponse.successResponse(point, "포인트 조회 성공", 2000));
 
+	}
+
+	@PostMapping("/profile")
+	ResponseEntity<ApiResponse<?>> uploadProfile(@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@RequestPart(value = "photos") MultipartFile file) {
+
+		userInfoService.uploadProfile(userDetails.getUser().getNickname(), file);
+
+		return ResponseEntity.ok(ApiResponse.successResponse(null, "프로필 이미지 업로드 성공", 2001));
 	}
 
 }

--- a/src/main/java/com/backend/naildp/entity/Profile.java
+++ b/src/main/java/com/backend/naildp/entity/Profile.java
@@ -9,12 +9,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Profile extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/backend/naildp/entity/UsersProfile.java
+++ b/src/main/java/com/backend/naildp/entity/UsersProfile.java
@@ -1,10 +1,15 @@
 package com.backend.naildp.entity;
 
+import com.backend.naildp.common.ProfileType;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,25 +21,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Profile extends BaseEntity {
+public class UsersProfile {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "profile_id")
+	@Column(name = "users_profile_id")
 	private Long id;
 
-	@Column(nullable = false)
-	private String profileUrl;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "profile_id")
+	private Profile profile;
 
-	@Column(nullable = false)
-	private Boolean thumbnail;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
-	@Column(nullable = false)
-	private String name;
-
-	public Profile(String profileUrl, String name, boolean thumbnail) {
-		this.profileUrl = profileUrl;
-		this.name = name;
-		this.thumbnail = thumbnail;
-	}
+	private ProfileType profileType;
 }

--- a/src/main/java/com/backend/naildp/entity/UsersProfile.java
+++ b/src/main/java/com/backend/naildp/entity/UsersProfile.java
@@ -4,6 +4,8 @@ import com.backend.naildp.common.ProfileType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,5 +38,7 @@ public class UsersProfile {
 	@JoinColumn(name = "user_id")
 	private User user;
 
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false)
 	private ProfileType profileType;
 }

--- a/src/main/java/com/backend/naildp/repository/ProfileRepository.java
+++ b/src/main/java/com/backend/naildp/repository/ProfileRepository.java
@@ -1,5 +1,6 @@
 package com.backend.naildp.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import com.backend.naildp.entity.User;
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
 	Optional<Profile> findProfileUrlByThumbnailIsTrueAndUser(User user);
+
+	List<Profile> findProfilesByThumbnailIsFalseAndUser(User user);
 }

--- a/src/main/java/com/backend/naildp/repository/ProfileRepository.java
+++ b/src/main/java/com/backend/naildp/repository/ProfileRepository.java
@@ -1,16 +1,12 @@
 package com.backend.naildp.repository;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.backend.naildp.entity.Profile;
-import com.backend.naildp.entity.User;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
-	Optional<Profile> findProfileUrlByThumbnailIsTrueAndUser(User user);
+	// Optional<Profile> findProfileUrlByThumbnailIsTrueAndUser(User user);
 
-	List<Profile> findProfilesByThumbnailIsFalseAndUser(User user);
+	// List<Profile> findProfilesByThumbnailIsFalseAndUser(User user);
 }

--- a/src/main/java/com/backend/naildp/repository/UsersProfileRepository.java
+++ b/src/main/java/com/backend/naildp/repository/UsersProfileRepository.java
@@ -1,0 +1,16 @@
+package com.backend.naildp.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.backend.naildp.entity.UsersProfile;
+
+public interface UsersProfileRepository extends JpaRepository<UsersProfile, Long> {
+
+	@Query("select p.profileUrl from UsersProfile up join up.profile p where up.user.nickname = :nickname and p.thumbnail = true")
+	Optional<String> findProfileUrlByUserIdAndThumbnailTrue(@Param("nickname") String nickname);
+
+}

--- a/src/main/java/com/backend/naildp/service/AuthService.java
+++ b/src/main/java/com/backend/naildp/service/AuthService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.backend.naildp.common.CookieUtil;
+import com.backend.naildp.common.ProfileType;
 import com.backend.naildp.common.UserRole;
 import com.backend.naildp.dto.auth.KakaoUserInfoDto;
 import com.backend.naildp.dto.auth.LoginRequestDto;
@@ -16,6 +17,7 @@ import com.backend.naildp.dto.auth.PhoneNumberRequestDto;
 import com.backend.naildp.entity.Profile;
 import com.backend.naildp.entity.SocialLogin;
 import com.backend.naildp.entity.User;
+import com.backend.naildp.entity.UsersProfile;
 import com.backend.naildp.exception.ApiResponse;
 import com.backend.naildp.exception.CustomException;
 import com.backend.naildp.exception.ErrorCode;
@@ -24,6 +26,7 @@ import com.backend.naildp.jwt.JwtUtil;
 import com.backend.naildp.repository.ProfileRepository;
 import com.backend.naildp.repository.SocialLoginRepository;
 import com.backend.naildp.repository.UserRepository;
+import com.backend.naildp.repository.UsersProfileRepository;
 
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
@@ -42,6 +45,7 @@ public class AuthService {
 	private final ProfileRepository profileRepository;
 	private final JwtUtil jwtUtil;
 	private final JwtAuthorizationFilter jwtAuthorizationFilter;
+	private final UsersProfileRepository usersProfileRepository;
 
 	@Transactional
 	public ResponseEntity<ApiResponse<?>> signupUser(LoginRequestDto loginRequestDto, HttpServletRequest req,
@@ -59,8 +63,20 @@ public class AuthService {
 		socialLoginRepository.save(socialLogin);
 
 		if (userInfo.getProfileUrl() != null) {
-			Profile profile = new Profile(user, userInfo.getProfileUrl(), userInfo.getProfileUrl(), true);
+			Profile profile = Profile.builder()
+				.profileUrl(userInfo.getProfileUrl())
+				.name(userInfo.getProfileUrl())
+				.thumbnail(true)
+				.build();
+
+			UsersProfile usersProfile = UsersProfile.builder()
+				.profile(profile)
+				.user(user)
+				.profileType(ProfileType.CUSTOMIZATION)
+				.build();
+
 			profileRepository.save(profile);
+			usersProfileRepository.save(usersProfile);
 		}
 
 		cookieUtil.deleteCookie("userInfo", req, res);

--- a/src/main/java/com/backend/naildp/service/UserInfoService.java
+++ b/src/main/java/com/backend/naildp/service/UserInfoService.java
@@ -20,6 +20,7 @@ import com.backend.naildp.repository.FollowRepository;
 import com.backend.naildp.repository.PostRepository;
 import com.backend.naildp.repository.ProfileRepository;
 import com.backend.naildp.repository.UserRepository;
+import com.backend.naildp.repository.UsersProfileRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,6 +34,7 @@ public class UserInfoService {
 	private final ArchivePostRepository archivePostRepository;
 	private final FollowRepository followRepository;
 	private final S3Service s3Service;
+	private final UsersProfileRepository usersProfileRepository;
 
 	public UserInfoResponseDto getUserInfo(String nickname) {
 
@@ -57,13 +59,13 @@ public class UserInfoService {
 				.count();
 		}
 
-		Profile profile = profileRepository.findProfileUrlByThumbnailIsTrueAndUser(user)
+		String profileUrl = usersProfileRepository.findProfileUrlByUserIdAndThumbnailTrue(user.getNickname())
 			.orElseThrow(() -> new CustomException("설정된 프로필 썸네일이 없습니다.", ErrorCode.NOT_FOUND));
 
 		return UserInfoResponseDto.builder()
 			.nickname(user.getNickname())
 			.point(user.getPoint())
-			.profileUrl(profile.getProfileUrl())
+			.profileUrl(profileUrl)
 			.postsCount(postRepository.countPostsByUserAndTempSaveIsFalse(user))
 			.saveCount(count)
 			.followerCount(followRepository.countFollowersByUserNickname(user.getNickname()))
@@ -88,7 +90,6 @@ public class UserInfoService {
 			.profileUrl(fileRequestDto.getFileUrl())
 			.thumbnail(false)
 			.name(fileRequestDto.getFileName())
-			.user(user)
 			.build();
 
 		profileRepository.save(profile);

--- a/src/main/java/com/backend/naildp/service/UserInfoService.java
+++ b/src/main/java/com/backend/naildp/service/UserInfoService.java
@@ -5,14 +5,17 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.backend.naildp.common.Boundary;
+import com.backend.naildp.common.ProfileType;
 import com.backend.naildp.dto.post.FileRequestDto;
 import com.backend.naildp.dto.userInfo.UserInfoResponseDto;
 import com.backend.naildp.entity.ArchivePost;
 import com.backend.naildp.entity.Profile;
 import com.backend.naildp.entity.User;
+import com.backend.naildp.entity.UsersProfile;
 import com.backend.naildp.exception.CustomException;
 import com.backend.naildp.exception.ErrorCode;
 import com.backend.naildp.repository.ArchivePostRepository;
@@ -36,6 +39,7 @@ public class UserInfoService {
 	private final S3Service s3Service;
 	private final UsersProfileRepository usersProfileRepository;
 
+	@Transactional(readOnly = true)
 	public UserInfoResponseDto getUserInfo(String nickname) {
 
 		User user = userRepository.findByNickname(nickname)
@@ -80,6 +84,7 @@ public class UserInfoService {
 		return response;
 	}
 
+	@Transactional
 	public void uploadProfile(String nickname, MultipartFile file) {
 		User user = userRepository.findByNickname(nickname)
 			.orElseThrow(() -> new CustomException("nickname 으로 회원을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
@@ -92,7 +97,14 @@ public class UserInfoService {
 			.name(fileRequestDto.getFileName())
 			.build();
 
+		UsersProfile usersProfile = UsersProfile.builder()
+			.user(user)
+			.profile(profile)
+			.profileType(ProfileType.CUSTOMIZATION)
+			.build();
+
 		profileRepository.save(profile);
+		usersProfileRepository.save(usersProfile);
 	}
 
 }

--- a/src/main/java/com/backend/naildp/service/UserInfoService.java
+++ b/src/main/java/com/backend/naildp/service/UserInfoService.java
@@ -5,8 +5,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.backend.naildp.common.Boundary;
+import com.backend.naildp.dto.post.FileRequestDto;
 import com.backend.naildp.dto.userInfo.UserInfoResponseDto;
 import com.backend.naildp.entity.ArchivePost;
 import com.backend.naildp.entity.Profile;
@@ -75,4 +77,21 @@ public class UserInfoService {
 		response.put("point", user.getPoint());
 		return response;
 	}
+
+	public void uploadProfile(String nickname, MultipartFile file) {
+		User user = userRepository.findByNickname(nickname)
+			.orElseThrow(() -> new CustomException("nickname 으로 회원을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
+
+		FileRequestDto fileRequestDto = s3Service.saveFile(file);
+
+		Profile profile = Profile.builder()
+			.profileUrl(fileRequestDto.getFileUrl())
+			.thumbnail(false)
+			.name(fileRequestDto.getFileName())
+			.user(user)
+			.build();
+
+		profileRepository.save(profile);
+	}
+
 }

--- a/src/main/java/com/backend/naildp/service/UserInfoService.java
+++ b/src/main/java/com/backend/naildp/service/UserInfoService.java
@@ -1,6 +1,8 @@
 package com.backend.naildp.service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 
@@ -28,6 +30,7 @@ public class UserInfoService {
 	private final ProfileRepository profileRepository;
 	private final ArchivePostRepository archivePostRepository;
 	private final FollowRepository followRepository;
+	private final S3Service s3Service;
 
 	public UserInfoResponseDto getUserInfo(String nickname) {
 
@@ -63,5 +66,13 @@ public class UserInfoService {
 			.saveCount(count)
 			.followerCount(followRepository.countFollowersByUserNickname(user.getNickname()))
 			.build();
+	}
+
+	public Map<String, Object> getPoint(String nickname) {
+		User user = userRepository.findByNickname(nickname)
+			.orElseThrow(() -> new CustomException("nickname 으로 회원을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
+		Map<String, Object> response = new HashMap<>();
+		response.put("point", user.getPoint());
+		return response;
 	}
 }

--- a/src/test/java/com/backend/naildp/repository/ProfileRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/ProfileRepositoryTest.java
@@ -11,11 +11,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import com.backend.naildp.common.ProfileType;
 import com.backend.naildp.common.UserRole;
 import com.backend.naildp.dto.auth.LoginRequestDto;
 import com.backend.naildp.entity.Profile;
 import com.backend.naildp.entity.SocialLogin;
 import com.backend.naildp.entity.User;
+import com.backend.naildp.entity.UsersProfile;
 
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
@@ -29,23 +31,33 @@ class ProfileRepositoryTest {
 	ProfileRepository profileRepository;
 
 	@Autowired
+	UsersProfileRepository usersProfileRepository;
+
+	@Autowired
 	EntityManager em;
 
 	private User user1;
 	private User user2;
 
-	private Profile user1Profile;
-	private Profile user2Profile;
+	private Profile profile1;
+	private Profile profile2;
+
+	private UsersProfile userProfile1;
+	private UsersProfile userProfile2;
 
 	@BeforeEach
 	void setup() {
 		user1 = createTestMember("mj@naver.com", "mj", "0101111", 1L);
 		user2 = createTestMember("jw@naver.com", "jw", "0102222", 2L);
 
-		user1Profile = createTestProfile(user1, "mjProfileUrl.jpg", "mjName", true);
-		user2Profile = createTestProfile(user2, "jwProfile.jpg", "jwName", false);
+		profile1 = createTestProfile("mjProfileUrl.jpg", "mjName", true);
+		profile2 = createTestProfile("jwProfile.jpg", "jwName", false);
+
+		userProfile1 = createTestUsersProfile(user1, profile1, ProfileType.CUSTOMIZATION);
+		userProfile2 = createTestUsersProfile(user2, profile2, ProfileType.CUSTOMIZATION);
 
 		em.clear();
+
 	}
 
 	@DisplayName("해당 유저의 썸네일이 설정된 프로필 찾기")
@@ -54,12 +66,14 @@ class ProfileRepositoryTest {
 		// Given
 
 		// When
-		Optional<Profile> foundProfile1 = profileRepository.findProfileUrlByThumbnailIsTrueAndUser(user1);
-		Optional<Profile> foundProfile2 = profileRepository.findProfileUrlByThumbnailIsTrueAndUser(user2);
+		Optional<String> foundProfile1 = usersProfileRepository.findProfileUrlByUserIdAndThumbnailTrue(
+			user1.getNickname());
+		Optional<String> foundProfile2 = usersProfileRepository.findProfileUrlByUserIdAndThumbnailTrue(
+			user2.getNickname());
 
 		// Then
 		assertThat(foundProfile1).isPresent();
-		assertThat(foundProfile1.get().getProfileUrl()).isEqualTo("mjProfileUrl.jpg");
+		assertThat(foundProfile1.get()).isEqualTo("mjProfileUrl.jpg");
 
 		assertThat(foundProfile2).isNotPresent();
 	}
@@ -73,9 +87,23 @@ class ProfileRepositoryTest {
 		return user;
 	}
 
-	private Profile createTestProfile(User user, String url, String name, boolean thumb) {
-		Profile profile = new Profile(user, url, name, thumb);
+	private Profile createTestProfile(String url, String name, boolean thumb) {
+		Profile profile = Profile.builder()
+			.profileUrl(url)
+			.thumbnail(thumb)
+			.name(name)
+			.build();
 		em.persist(profile);
 		return profile;
+	}
+
+	private UsersProfile createTestUsersProfile(User user, Profile profile, ProfileType profileType) {
+		UsersProfile usersProfile = UsersProfile.builder()
+			.user(user)
+			.profile(profile)
+			.profileType(profileType)
+			.build();
+		em.persist(usersProfile);
+		return usersProfile;
 	}
 }

--- a/src/test/java/com/backend/naildp/repository/UsersProfileRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/UsersProfileRepositoryTest.java
@@ -25,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class ProfileRepositoryTest {
+class UsersProfileRepositoryTest {
 
 	@Autowired
 	ProfileRepository profileRepository;

--- a/src/test/java/com/backend/naildp/service/UserInfoServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/UserInfoServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.backend.naildp.common.Boundary;
+import com.backend.naildp.common.ProfileType;
 import com.backend.naildp.common.UserRole;
 import com.backend.naildp.dto.userInfo.UserInfoResponseDto;
 import com.backend.naildp.entity.Archive;
@@ -24,12 +25,14 @@ import com.backend.naildp.entity.Follow;
 import com.backend.naildp.entity.Post;
 import com.backend.naildp.entity.Profile;
 import com.backend.naildp.entity.User;
+import com.backend.naildp.entity.UsersProfile;
 import com.backend.naildp.exception.CustomException;
 import com.backend.naildp.repository.ArchivePostRepository;
 import com.backend.naildp.repository.FollowRepository;
 import com.backend.naildp.repository.PostRepository;
 import com.backend.naildp.repository.ProfileRepository;
 import com.backend.naildp.repository.UserRepository;
+import com.backend.naildp.repository.UsersProfileRepository;
 
 class UserInfoServiceTest {
 	@Mock
@@ -44,6 +47,8 @@ class UserInfoServiceTest {
 	private FollowRepository followRepository;
 	@InjectMocks
 	private UserInfoService userInfoService;
+	@Mock
+	private UsersProfileRepository usersProfileRepository;
 
 	private User user1;
 	private User user2;
@@ -58,12 +63,22 @@ class UserInfoServiceTest {
 
 	private int followerCount;
 
+	private UsersProfile userProfile1;
+	private UsersProfile userProfile2;
+
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
 
 		user1 = new User("alswl", "010-1234-5678", 1000L, UserRole.USER);
-		profile1 = new Profile(user1, "alswl.profileUrl.jpg", "name", true);
+		profile1 = new Profile("alswl.profileUrl.jpg", "name", true);
+
+		userProfile1 = UsersProfile.builder()
+			.user(user1)
+			.profile(profile1)
+			.profileType(ProfileType.CUSTOMIZATION)
+			.build();
+
 		post1 = new Post(user1, "alswl postContent", 0L, Boundary.ALL, false);
 
 		user2 = new User("jw", "010-9876-5432", 0L, UserRole.USER);
@@ -84,7 +99,8 @@ class UserInfoServiceTest {
 		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
 			List.of(archivePost1));
 		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(Collections.emptyList());
-		given(profileRepository.findProfileUrlByThumbnailIsTrueAndUser(user1)).willReturn(Optional.of(profile1));
+		given(usersProfileRepository.findProfileUrlByUserIdAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.of(profile1.getProfileUrl()));
 		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
 		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
 
@@ -111,7 +127,8 @@ class UserInfoServiceTest {
 		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
 			List.of(archivePost1));
 		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(Collections.emptyList());
-		given(profileRepository.findProfileUrlByThumbnailIsTrueAndUser(user1)).willReturn(Optional.of(profile1));
+		given(usersProfileRepository.findProfileUrlByUserIdAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.of(profile1.getProfileUrl()));
 		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
 		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
 
@@ -136,7 +153,8 @@ class UserInfoServiceTest {
 			List.of(archivePost1, archivePost2));
 		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(
 			List.of(user2.getNickname(), "user3"));
-		given(profileRepository.findProfileUrlByThumbnailIsTrueAndUser(user1)).willReturn(Optional.of(profile1));
+		given(usersProfileRepository.findProfileUrlByUserIdAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.of(profile1.getProfileUrl()));
 		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
 		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
 
@@ -158,7 +176,8 @@ class UserInfoServiceTest {
 		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
 			List.of(archivePost1));
 		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(List.of(user2.getNickname()));
-		given(profileRepository.findProfileUrlByThumbnailIsTrueAndUser(user1)).willReturn(Optional.of(profile1));
+		given(usersProfileRepository.findProfileUrlByUserIdAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.of(profile1.getProfileUrl()));
 		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
 		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
 
@@ -184,7 +203,8 @@ class UserInfoServiceTest {
 	void testGetUserInfo_NoProfileThumbnail() {
 		// Given
 		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
-		given(profileRepository.findProfileUrlByThumbnailIsTrueAndUser(user1)).willReturn(Optional.empty());
+		given(usersProfileRepository.findProfileUrlByUserIdAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.empty());
 
 		// Then
 		assertThrows(CustomException.class, () -> userInfoService.getUserInfo("alswl"));


### PR DESCRIPTION
### ✅ PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [x] Other...

### 🖋️ 요약(Summary)

- 기본, 아이콘 이미지를 db에 저장, 관리하는것을로 변경
    - UsersProfile 테이블 추가

### 📝 상세 내용(Describe your changes)
- Users 와 profile의 다대다 파생테이블인 UsersProfile 테이블 생성
- AuthService의 signUp 메서드에서 profile을 설정하는 부분 수정
- UserInfoService의 getUserInfo 메서드에서 Thumbnail 가져오기 수정
- ProfileRepositoryTest 및 UserInfoServiceTest 수정

###
#31 