### PR TITLE
[Refactor] : 좋아요 게시물 조회 API 리펙토링 및 PostService 분리

### DIFF
--- a/src/main/java/com/backend/naildp/controller/HomeController.java
+++ b/src/main/java/com/backend/naildp/controller/HomeController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.backend.naildp.dto.home.PostSummaryResponse;
 import com.backend.naildp.exception.ApiResponse;
+import com.backend.naildp.service.PostInfoService;
 import com.backend.naildp.service.PostService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class HomeController {
 
-	private final PostService postService;
+	// private final PostService postService;
+	private final PostInfoService postInfoService;
 
 	@GetMapping("/home")
 	public ResponseEntity<?> homePosts(
@@ -31,11 +33,11 @@ public class HomeController {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
 		if (authentication == null) {
-			PostSummaryResponse postSummaryResponse = postService.homePosts(choice, size, cursorPostId, "");
+			PostSummaryResponse postSummaryResponse = postInfoService.homePosts(choice, size, cursorPostId, "");
 			return ResponseEntity.ok(ApiResponse.successResponse(postSummaryResponse, "최신 게시물 조회", 2000));
 		}
 
-		PostSummaryResponse postSummaryResponse = postService.homePosts(choice, size, cursorPostId,
+		PostSummaryResponse postSummaryResponse = postInfoService.homePosts(choice, size, cursorPostId,
 			authentication.getName());
 		return ResponseEntity.ok(ApiResponse.successResponse(postSummaryResponse, "최신 게시물 조회", 2000));
 	}
@@ -44,7 +46,7 @@ public class HomeController {
 	public ResponseEntity<?> likedPost(@AuthenticationPrincipal UserDetails userDetails,
 		@RequestParam(required = false, defaultValue = "20", value = "size") int size,
 		@RequestParam(required = false, defaultValue = "-1", value = "oldestPostLikeId") long postLikeId) {
-		PostSummaryResponse likedPostsResponses = postService.findLikedPost(userDetails.getUsername(), size,
+		PostSummaryResponse likedPostsResponses = postInfoService.findLikedPost(userDetails.getUsername(), size,
 			postLikeId);
 		return ResponseEntity.ok(ApiResponse.successResponse(likedPostsResponses, "좋아요 체크한 게시물 조회", 2000));
 	}

--- a/src/main/java/com/backend/naildp/controller/HomeController.java
+++ b/src/main/java/com/backend/naildp/controller/HomeController.java
@@ -1,6 +1,5 @@
 package com.backend.naildp.controller;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.backend.naildp.dto.home.HomePostResponse;
 import com.backend.naildp.dto.home.PostSummaryResponse;
 import com.backend.naildp.exception.ApiResponse;
 import com.backend.naildp.service.PostService;
@@ -44,8 +42,10 @@ public class HomeController {
 
 	@GetMapping("/posts/like")
 	public ResponseEntity<?> likedPost(@AuthenticationPrincipal UserDetails userDetails,
-		@RequestParam(required = false, defaultValue = "0", value = "page") int pageNumber) {
-		Page<HomePostResponse> likedPostsResponses = postService.findLikedPost(userDetails.getUsername(), pageNumber);
+		@RequestParam(required = false, defaultValue = "20", value = "size") int size,
+		@RequestParam(required = false, defaultValue = "-1", value = "oldestPostLikeId") long postLikeId) {
+		PostSummaryResponse likedPostsResponses = postService.findLikedPost(userDetails.getUsername(), size,
+			postLikeId);
 		return ResponseEntity.ok(ApiResponse.successResponse(likedPostsResponses, "좋아요 체크한 게시물 조회", 2000));
 	}
 }

--- a/src/main/java/com/backend/naildp/dto/home/PostSummaryResponse.java
+++ b/src/main/java/com/backend/naildp/dto/home/PostSummaryResponse.java
@@ -56,4 +56,12 @@ public class PostSummaryResponse {
 		Long oldestPostId = latestPosts.getContent().get(latestPosts.getNumberOfElements() - 1).getId();
 		return new PostSummaryResponse(oldestPostId, latestPosts.map(HomePostResponse::recentPostForAnonymous));
 	}
+
+	public static PostSummaryResponse createLikedPostSummary(Slice<Post> likedPostSlice, List<Post> savedPosts) {
+		log.info("PostSummaryResponse 좋아요 체크한 게시물 응답 만들기 - 정적 팩토리 메서드");
+		Long oldestPostLikeId = likedPostSlice.getContent().get(likedPostSlice.getNumberOfElements() - 1).getId();
+		log.info("PostSummaryResponse 응답");
+		return new PostSummaryResponse(oldestPostLikeId,
+			likedPostSlice.map(post -> HomePostResponse.likedPostResponse(post, savedPosts)));
+	}
 }

--- a/src/main/java/com/backend/naildp/dto/home/PostSummaryResponse.java
+++ b/src/main/java/com/backend/naildp/dto/home/PostSummaryResponse.java
@@ -1,8 +1,11 @@
 package com.backend.naildp.dto.home;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.security.core.parameters.P;
 
 import com.backend.naildp.entity.Post;
 
@@ -41,5 +44,16 @@ public class PostSummaryResponse {
 			oldestPostId = posts.get(posts.size() - 1).getId();
 		}
 		postSummaryList = likedPosts.map(post -> HomePostResponse.likedPostResponse(post, savedPosts));
+	}
+
+	public static PostSummaryResponse createEmptyResponse() {
+		log.info("게시물이 없기 때문에 빈 응답 리턴");
+		return new PostSummaryResponse(-1L, new SliceImpl<>(new ArrayList<>()));
+	}
+
+	public static PostSummaryResponse createForAnonymous(Slice<Post> latestPosts) {
+		log.info("PostSummaryResponse static 응답값 만들기 - 익명 사용자");
+		Long oldestPostId = latestPosts.getContent().get(latestPosts.getNumberOfElements() - 1).getId();
+		return new PostSummaryResponse(oldestPostId, latestPosts.map(HomePostResponse::recentPostForAnonymous));
 	}
 }

--- a/src/main/java/com/backend/naildp/dto/home/PostSummaryResponse.java
+++ b/src/main/java/com/backend/naildp/dto/home/PostSummaryResponse.java
@@ -31,4 +31,15 @@ public class PostSummaryResponse {
 		oldestPostId = latestPosts.getContent().get(latestPosts.getNumberOfElements() - 1).getId();
 		postSummaryList = latestPosts.map(HomePostResponse::recentPostForAnonymous);
 	}
+
+	public PostSummaryResponse(Slice<Post> likedPosts, List<Post> savedPosts) {
+		log.info("PostSummaryResponse 좋아요체크한 게시물 응답 만들기");
+		List<Post> posts = likedPosts.getContent();
+		if (posts.isEmpty()) {
+			oldestPostId = null;
+		} else {
+			oldestPostId = posts.get(posts.size() - 1).getId();
+		}
+		postSummaryList = likedPosts.map(post -> HomePostResponse.likedPostResponse(post, savedPosts));
+	}
 }

--- a/src/main/java/com/backend/naildp/repository/PostLikeRepository.java
+++ b/src/main/java/com/backend/naildp/repository/PostLikeRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.backend.naildp.common.Boundary;
 import com.backend.naildp.entity.PostLike;
+import com.backend.naildp.entity.User;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
@@ -27,4 +29,20 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 		+ "where pl.user.nickname = :nickname and p.boundary <> :boundary and p.tempSave = false")
 	Page<PostLike> findPagedPostLikesByBoundaryOpened(PageRequest pageRequest, @Param("nickname") String nickname,
 		@Param("boundary") Boundary boundary);
+
+	@Query("select pl from PostLike pl join fetch pl.post p"
+		+ " where pl.user.nickname = :nickname"
+		+ " and p.tempSave = false"
+		+ " and (p.boundary = 'ALL' or (p.boundary = 'FOLLOW' and p.user in :following))")
+	Slice<PostLike> findPostLikesByFollowing(@Param("nickname") String nickname,
+		@Param("following") List<User> following, PageRequest pageRequest);
+
+	@Query("select pl from PostLike pl join fetch pl.post p"
+		+ " where pl.user.nickname = :nickname"
+		+ " and p.tempSave = false"
+		+ " and pl.id < :id"
+		+ " and (p.boundary = 'ALL' or (p.boundary = 'FOLLOW' and p.user in :following))")
+	Slice<PostLike> findPostLikesByIdAndFollowing(@Param("nickname") String nickname, @Param("id") Long cursorId,
+		@Param("following") List<User> following, PageRequest pageRequest);
+
 }

--- a/src/main/java/com/backend/naildp/service/PostInfoService.java
+++ b/src/main/java/com/backend/naildp/service/PostInfoService.java
@@ -1,0 +1,122 @@
+package com.backend.naildp.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.backend.naildp.common.Boundary;
+import com.backend.naildp.dto.home.PostSummaryResponse;
+import com.backend.naildp.entity.ArchivePost;
+import com.backend.naildp.entity.Post;
+import com.backend.naildp.entity.PostLike;
+import com.backend.naildp.entity.User;
+import com.backend.naildp.exception.CustomException;
+import com.backend.naildp.exception.ErrorCode;
+import com.backend.naildp.repository.ArchivePostRepository;
+import com.backend.naildp.repository.FollowRepository;
+import com.backend.naildp.repository.PostLikeRepository;
+import com.backend.naildp.repository.PostRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostInfoService {
+
+	private final PostRepository postRepository;
+	private final ArchivePostRepository archivePostRepository;
+	private final PostLikeRepository postLikeRepository;
+	private final FollowRepository followRepository;
+
+	public PostSummaryResponse homePosts(String choice, int size, long cursorPostId, String nickname) {
+		PageRequest pageRequest = createPageRequest(size, "id");
+
+		if (!StringUtils.hasText(nickname)) {
+			log.info("익명사용자 응답");
+			Slice<Post> recentPosts = getRecentOpenedPosts(cursorPostId, pageRequest);
+
+			if (recentPosts.isEmpty()) {
+				throw new CustomException("최신 게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
+			}
+
+			return PostSummaryResponse.createForAnonymous(recentPosts);
+		}
+
+		List<User> followingUser = followRepository.findFollowingUserByFollowerNickname(nickname);
+		Slice<Post> recentPosts = getRecentPosts(cursorPostId, followingUser, pageRequest);
+
+		if (recentPosts.isEmpty()) {
+			log.info("최신 게시물이 없습니다.");
+			throw new CustomException("게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
+		}
+
+		List<ArchivePost> archivePosts = archivePostRepository.findAllByArchiveUserNickname(nickname);
+		List<Post> savedPosts = archivePosts.stream().map(ArchivePost::getPost).collect(Collectors.toList());
+
+		List<PostLike> postLikes = postLikeRepository.findAllByUserNickname(nickname);
+		List<Post> likedPosts = postLikes.stream().map(PostLike::getPost).collect(Collectors.toList());
+
+		return new PostSummaryResponse(recentPosts, savedPosts, likedPosts);
+	}
+
+	public PostSummaryResponse findLikedPost(String nickname, int pageSize, long cursorId) {
+		PageRequest pageRequest = createPageRequest(pageSize, "createdDate");
+
+		// 좋아요한 게시글 조회
+		List<User> followingUsers = followRepository.findFollowingUserByFollowerNickname(nickname);
+		Slice<PostLike> postLikes = getOpenedPostLikes(cursorId, nickname, followingUsers, pageRequest);
+		Slice<Post> likedPosts = postLikes.map(PostLike::getPost);
+
+		if (likedPosts.isEmpty()) {
+			log.info("좋아요한 게시물이 없다.");
+			throw new CustomException("좋아요한 게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
+		}
+
+		// 게시글 저장 여부 체크
+		List<ArchivePost> archivePosts = archivePostRepository.findAllByArchiveUserNickname(nickname);
+		List<Post> savedPosts = archivePosts.stream().map(ArchivePost::getPost).collect(Collectors.toList());
+
+		// return new PostSummaryResponse(likedPosts, savedPosts);
+		return PostSummaryResponse.createLikedPostSummary(likedPosts, savedPosts);
+	}
+
+	private PageRequest createPageRequest(int size, String id) {
+		return PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, id));
+	}
+
+	private Slice<PostLike> getOpenedPostLikes(long cursorPostLikeId, String nickname, List<User> followingUsers,
+		PageRequest pageRequest) {
+		if (isFirstPage(cursorPostLikeId)) {
+			return postLikeRepository.findPostLikesByFollowing(nickname, followingUsers, pageRequest);
+		}
+		return postLikeRepository.findPostLikesByIdAndFollowing(nickname, cursorPostLikeId, followingUsers,
+			pageRequest);
+	}
+
+	private Slice<Post> getRecentOpenedPosts(long cursorPostId, PageRequest pageRequest) {
+		if (isFirstPage(cursorPostId)) {
+			return postRepository.findPostsByBoundaryAndTempSaveFalse(Boundary.ALL, pageRequest);
+		}
+		return postRepository.findPostsByIdBeforeAndBoundaryAndTempSaveFalse(cursorPostId, Boundary.ALL, pageRequest);
+	}
+
+	private Slice<Post> getRecentPosts(long cursorPostId, List<User> followingUser, PageRequest pageRequest) {
+		if (isFirstPage(cursorPostId)) {
+			return postRepository.findRecentPostsByFollowing(followingUser, pageRequest);
+		}
+		return postRepository.findRecentPostsByIdAndFollowing(cursorPostId, followingUser, pageRequest);
+	}
+
+	private boolean isFirstPage(long cursorPostId) {
+		return cursorPostId == -1L;
+	}
+}

--- a/src/main/java/com/backend/naildp/service/PostService.java
+++ b/src/main/java/com/backend/naildp/service/PostService.java
@@ -61,18 +61,21 @@ public class PostService {
 		PageRequest pageRequest = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
 
 		if (!StringUtils.hasText(nickname)) {
-			log.info("익명사용자 확인");
+			log.info("익명사용자 응답");
 			Slice<Post> recentPosts = getRecentOpenedPosts(cursorPostId, pageRequest);
 
-			return recentPosts.isEmpty() ? PostSummaryResponse.createEmptyResponse() :
-				PostSummaryResponse.createForAnonymous(recentPosts);
+			if (recentPosts.isEmpty()) {
+				throw new CustomException("최신 게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
+			}
+
+			return PostSummaryResponse.createForAnonymous(recentPosts);
 		}
 
 		List<User> followingUser = followRepository.findFollowingUserByFollowerNickname(nickname);
 		Slice<Post> recentPosts = getRecentPosts(cursorPostId, followingUser, pageRequest);
 
 		if (recentPosts.isEmpty()) {
-			log.debug("최신 게시물이 하나도 없습니다.");
+			log.info("최신 게시물이 없습니다.");
 			throw new CustomException("게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
 		}
 

--- a/src/main/java/com/backend/naildp/service/PostService.java
+++ b/src/main/java/com/backend/naildp/service/PostService.java
@@ -110,6 +110,10 @@ public class PostService {
 		Slice<PostLike> postLikes = getOpenedPostLikes(cursorId, nickname, followingUsers, pageRequest);
 		Slice<Post> likedPosts = postLikes.map(PostLike::getPost);
 
+		if (likedPosts.isEmpty()) {
+			throw new CustomException("좋아요한 게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
+		}
+
 		// 게시글 저장 여부 체크
 		List<ArchivePost> archivePosts = archivePostRepository.findAllByArchiveUserNickname(nickname);
 		List<Post> savedPosts = archivePosts.stream()

--- a/src/main/java/com/backend/naildp/service/PostService.java
+++ b/src/main/java/com/backend/naildp/service/PostService.java
@@ -3,7 +3,6 @@ package com.backend.naildp.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -13,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.backend.naildp.common.Boundary;
-import com.backend.naildp.dto.home.HomePostResponse;
 import com.backend.naildp.dto.home.PostSummaryResponse;
 import com.backend.naildp.dto.post.PostRequestDto;
 import com.backend.naildp.dto.post.TagRequestDto;
@@ -104,13 +102,13 @@ public class PostService {
 		return ResponseEntity.ok().body(ApiResponse.successResponse(post, "게시글 작성이 완료되었습니다", 2001));
 	}
 
-	public Page<HomePostResponse> findLikedPost(String nickname, int pageNumber) {
-		PageRequest pageRequest = PageRequest.of(pageNumber, 20, Sort.by(Sort.Direction.DESC, "createdDate"));
+	public PostSummaryResponse findLikedPost(String nickname, int pageSize, long cursorId) {
+		PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdDate"));
 
 		// 좋아요한 게시글 조회
-		Page<PostLike> postLikes = postLikeRepository.findPagedPostLikesByBoundaryOpened(pageRequest, nickname,
-			Boundary.NONE);
-		Page<Post> likedPost = postLikes.map(PostLike::getPost);
+		List<User> followingUsers = followRepository.findFollowingUserByFollowerNickname(nickname);
+		Slice<PostLike> postLikes = getOpenedPostLikes(cursorId, nickname, followingUsers, pageRequest);
+		Slice<Post> likedPosts = postLikes.map(PostLike::getPost);
 
 		// 게시글 저장 여부 체크
 		List<ArchivePost> archivePosts = archivePostRepository.findAllByArchiveUserNickname(nickname);
@@ -118,7 +116,16 @@ public class PostService {
 			.map(ArchivePost::getPost)
 			.collect(Collectors.toList());
 
-		return likedPost.map(post -> HomePostResponse.likedPostResponse(post, savedPosts));
+		return new PostSummaryResponse(likedPosts, savedPosts);
+	}
+
+	private Slice<PostLike> getOpenedPostLikes(long cursorPostLikeId, String nickname, List<User> followingUsers,
+		PageRequest pageRequest) {
+		if (isFirstPage(cursorPostLikeId)) {
+			return postLikeRepository.findPostLikesByFollowing(nickname, followingUsers, pageRequest);
+		}
+		return postLikeRepository.findPostLikesByIdAndFollowing(nickname, cursorPostLikeId, followingUsers,
+			pageRequest);
 	}
 
 	private Slice<Post> getRecentOpenedPosts(long cursorPostId, PageRequest pageRequest) {

--- a/src/main/java/com/backend/naildp/service/PostService.java
+++ b/src/main/java/com/backend/naildp/service/PostService.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,8 +61,11 @@ public class PostService {
 		PageRequest pageRequest = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
 
 		if (!StringUtils.hasText(nickname)) {
+			log.info("익명사용자 확인");
 			Slice<Post> recentPosts = getRecentOpenedPosts(cursorPostId, pageRequest);
-			return new PostSummaryResponse(recentPosts);
+
+			return recentPosts.isEmpty() ? PostSummaryResponse.createEmptyResponse() :
+				PostSummaryResponse.createForAnonymous(recentPosts);
 		}
 
 		List<User> followingUser = followRepository.findFollowingUserByFollowerNickname(nickname);
@@ -99,7 +103,7 @@ public class PostService {
 			.user(user)
 			.postContent(postRequestDto.getPostContent())
 			.boundary(postRequestDto.getBoundary())
-			.tempSave(true)
+			.tempSave(false)
 			.build();
 
 		postRepository.save(post);

--- a/src/main/java/com/backend/naildp/service/PostService.java
+++ b/src/main/java/com/backend/naildp/service/PostService.java
@@ -132,6 +132,7 @@ public class PostService {
 		Slice<Post> likedPosts = postLikes.map(PostLike::getPost);
 
 		if (likedPosts.isEmpty()) {
+			log.info("좋아요한 게시물이 없다.");
 			throw new CustomException("좋아요한 게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
 		}
 
@@ -139,7 +140,8 @@ public class PostService {
 		List<ArchivePost> archivePosts = archivePostRepository.findAllByArchiveUserNickname(nickname);
 		List<Post> savedPosts = archivePosts.stream().map(ArchivePost::getPost).collect(Collectors.toList());
 
-		return new PostSummaryResponse(likedPosts, savedPosts);
+		// return new PostSummaryResponse(likedPosts, savedPosts);
+		return PostSummaryResponse.createLikedPostSummary(likedPosts, savedPosts);
 	}
 
 	private Slice<PostLike> getOpenedPostLikes(long cursorPostLikeId, String nickname, List<User> followingUsers,

--- a/src/test/java/com/backend/naildp/controller/HomeControllerUnitTest.java
+++ b/src/test/java/com/backend/naildp/controller/HomeControllerUnitTest.java
@@ -183,6 +183,29 @@ class HomeControllerUnitTest {
 			.andDo(print());
 	}
 
+	@DisplayName("좋아요한 게시물 조회 API 예외 - 조회할 좋아요한 게시물이 없을 때")
+	@Test
+	@WithMockUser(username = "testUser", roles = {"USER"})
+	void likedPostApiException() throws Exception {
+		//given
+		CustomException customException = new CustomException("좋아요한 게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
+		ApiResponse<?> apiResponse = ApiResponse.of(customException.getErrorCode());
+		apiResponse.setMessage(customException.getMessage());
+		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+		when(postService.findLikedPost(anyString(), eq(20), anyLong())).thenThrow(customException);
+
+		//when & then
+		mvc.perform(get("/posts/like"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(content().json(jsonResponse))
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andDo(print());
+	}
+
 	private List<HomePostResponse> createLikedPostResponses() {
 		List<HomePostResponse> likedPostResponses = new ArrayList<>();
 		for (long i = 1; i <= 20; i++) {

--- a/src/test/java/com/backend/naildp/controller/HomeControllerUnitTest.java
+++ b/src/test/java/com/backend/naildp/controller/HomeControllerUnitTest.java
@@ -30,6 +30,7 @@ import com.backend.naildp.dto.home.PostSummaryResponse;
 import com.backend.naildp.exception.ApiResponse;
 import com.backend.naildp.exception.CustomException;
 import com.backend.naildp.exception.ErrorCode;
+import com.backend.naildp.service.PostInfoService;
 import com.backend.naildp.service.PostService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -40,8 +41,11 @@ class HomeControllerUnitTest {
 	@Autowired
 	MockMvc mvc;
 
+	// @MockBean
+	// PostService postService;
+
 	@MockBean
-	PostService postService;
+	PostInfoService postInfoService;
 
 	@Autowired
 	ObjectMapper objectMapper;
@@ -56,7 +60,7 @@ class HomeControllerUnitTest {
 			2000);
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
-		when(postService.homePosts(eq("NEW"), anyInt(), eq(-1L), eq("testUser"))).thenReturn(postSummaryResponse);
+		when(postInfoService.homePosts(eq("NEW"), anyInt(), eq(-1L), eq("testUser"))).thenReturn(postSummaryResponse);
 
 		//when & then
 		mvc.perform(get("/home").param("choice", "NEW"))
@@ -83,7 +87,7 @@ class HomeControllerUnitTest {
 		paramMap.add("choice", "NEW");
 		paramMap.add("size", "20");
 		paramMap.add("cursorPostId", "10");
-		when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq("testUser"))).thenReturn(postSummaryResponse);
+		when(postInfoService.homePosts(eq("NEW"), anyInt(), anyLong(), eq("testUser"))).thenReturn(postSummaryResponse);
 
 		mvc.perform((get("/home").queryParams(paramMap)))
 			.andExpect(status().isOk())
@@ -104,7 +108,7 @@ class HomeControllerUnitTest {
 			2000);
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
-		when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenReturn(postSummaryResponse);
+		when(postInfoService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenReturn(postSummaryResponse);
 
 		// when & then
 		mvc.perform((get("/home").param("choice", "NEW")))
@@ -126,7 +130,7 @@ class HomeControllerUnitTest {
 			2000);
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
-		when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenReturn(postSummaryResponse);
+		when(postInfoService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenReturn(postSummaryResponse);
 
 		// when & then
 		mvc.perform((get("/home").param("choice", "NEW")))
@@ -148,7 +152,7 @@ class HomeControllerUnitTest {
 		apiResponse.setMessage(exception.getMessage());
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
-		when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenThrow(exception);
+		when(postInfoService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenThrow(exception);
 
 		//when & then
 		mvc.perform(get("/home").param("choice", "NEW"))
@@ -170,7 +174,7 @@ class HomeControllerUnitTest {
 			"좋아요 체크한 게시물 조회", 2000);
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
-		when(postService.findLikedPost(anyString(), eq(20), anyLong())).thenReturn(postSummaryResponse);
+		when(postInfoService.findLikedPost(anyString(), eq(20), anyLong())).thenReturn(postSummaryResponse);
 
 		//when & then
 		mvc.perform(get("/posts/like"))
@@ -193,7 +197,7 @@ class HomeControllerUnitTest {
 		apiResponse.setMessage(customException.getMessage());
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
-		when(postService.findLikedPost(anyString(), eq(20), anyLong())).thenThrow(customException);
+		when(postInfoService.findLikedPost(anyString(), eq(20), anyLong())).thenThrow(customException);
 
 		//when & then
 		mvc.perform(get("/posts/like"))

--- a/src/test/java/com/backend/naildp/controller/HomeControllerUnitTest.java
+++ b/src/test/java/com/backend/naildp/controller/HomeControllerUnitTest.java
@@ -139,36 +139,16 @@ class HomeControllerUnitTest {
 			.andDo(print());
 	}
 
-	// @DisplayName("최신 게시글 조회 API 예외 테스트 - 게시글이 존재하지 않을때 4005 예외 발생")
-	// @Test
-	// void newPostsApiExceptionTest() throws Exception {
-	// 	//given
-	// 	CustomException exception = new CustomException("게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
-	// 	ApiResponse<?> apiResponse = ApiResponse.of(exception.getErrorCode());
-	// 	apiResponse.setMessage(exception.getMessage());
-	// 	String jsonResponse = objectMapper.writeValueAsString(apiResponse);
-	//
-	// 	when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenThrow(exception);
-	//
-	// 	//when & then
-	// 	mvc.perform(get("/home").param("choice", "NEW"))
-	// 		.andExpect(status().isOk())
-	// 		.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-	// 		.andExpect(content().json(jsonResponse))
-	// 		.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
-	// 		.andExpect(jsonPath("$.code").value(apiResponse.getCode()))
-	// 		.andDo(print());
-	// }
-
-	@DisplayName("최신 게시글 조회 API 테스트 - 게시글이 존재하지 않을때")
+	@DisplayName("최신 게시글 조회 API 예외 테스트 - 게시글이 존재하지 않을때 4005 예외 발생")
 	@Test
-	void newPostsApiWithoutPosts() throws Exception {
+	void newPostsApiExceptionTest() throws Exception {
 		//given
-		PostSummaryResponse emptyResponse = PostSummaryResponse.createEmptyResponse();
-		ApiResponse<PostSummaryResponse> apiResponse = ApiResponse.successResponse(emptyResponse, "최신 게시물 조회", 2000);
+		CustomException exception = new CustomException("게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
+		ApiResponse<?> apiResponse = ApiResponse.of(exception.getErrorCode());
+		apiResponse.setMessage(exception.getMessage());
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
-		when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenReturn(emptyResponse);
+		when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenThrow(exception);
 
 		//when & then
 		mvc.perform(get("/home").param("choice", "NEW"))

--- a/src/test/java/com/backend/naildp/controller/HomeControllerUnitTest.java
+++ b/src/test/java/com/backend/naildp/controller/HomeControllerUnitTest.java
@@ -139,16 +139,36 @@ class HomeControllerUnitTest {
 			.andDo(print());
 	}
 
-	@DisplayName("최신 게시글 조회 API 예외 테스트 - 게시글이 존재하지 않을때 4005 예외 발생")
+	// @DisplayName("최신 게시글 조회 API 예외 테스트 - 게시글이 존재하지 않을때 4005 예외 발생")
+	// @Test
+	// void newPostsApiExceptionTest() throws Exception {
+	// 	//given
+	// 	CustomException exception = new CustomException("게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
+	// 	ApiResponse<?> apiResponse = ApiResponse.of(exception.getErrorCode());
+	// 	apiResponse.setMessage(exception.getMessage());
+	// 	String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+	//
+	// 	when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenThrow(exception);
+	//
+	// 	//when & then
+	// 	mvc.perform(get("/home").param("choice", "NEW"))
+	// 		.andExpect(status().isOk())
+	// 		.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+	// 		.andExpect(content().json(jsonResponse))
+	// 		.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+	// 		.andExpect(jsonPath("$.code").value(apiResponse.getCode()))
+	// 		.andDo(print());
+	// }
+
+	@DisplayName("최신 게시글 조회 API 테스트 - 게시글이 존재하지 않을때")
 	@Test
-	void newPostsApiExceptionTest() throws Exception {
+	void newPostsApiWithoutPosts() throws Exception {
 		//given
-		CustomException exception = new CustomException("게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED);
-		ApiResponse<?> apiResponse = ApiResponse.of(exception.getErrorCode());
-		apiResponse.setMessage(exception.getMessage());
+		PostSummaryResponse emptyResponse = PostSummaryResponse.createEmptyResponse();
+		ApiResponse<PostSummaryResponse> apiResponse = ApiResponse.successResponse(emptyResponse, "최신 게시물 조회", 2000);
 		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
 
-		when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenThrow(exception);
+		when(postService.homePosts(eq("NEW"), anyInt(), anyLong(), eq(""))).thenReturn(emptyResponse);
 
 		//when & then
 		mvc.perform(get("/home").param("choice", "NEW"))

--- a/src/test/java/com/backend/naildp/repository/ArchivePostRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/ArchivePostRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import com.backend.naildp.common.Boundary;
 import com.backend.naildp.common.UserRole;
 import com.backend.naildp.dto.auth.LoginRequestDto;
+import com.backend.naildp.dto.post.FileRequestDto;
 import com.backend.naildp.entity.Archive;
 import com.backend.naildp.entity.ArchivePost;
 import com.backend.naildp.entity.Photo;
@@ -98,9 +99,12 @@ class ArchivePostRepositoryTest {
 
 		for (int i = 0; i < postCnt; i++) {
 			Post post = new Post(user, "" + i, 0L, Boundary.ALL, false);
-			Photo photo1 = new Photo(post, "thumbnailUrl-" + user.getNickname() + i,
-				"thumbnailName-" + user.getNickname() + i);
-			Photo photo2 = new Photo(post, "subUrl-" + user.getNickname() + i, "subName" + user.getNickname() + i);
+			FileRequestDto thumbnailFileRequestDto = new FileRequestDto("thumbnailName-" + user.getNickname() + i, 1L,
+				"thumbnailUrl-" + user.getNickname() + i);
+			FileRequestDto subPhotoFileRequestDto = new FileRequestDto("subName" + user.getNickname() + i, 1L,
+				"subUrl-" + user.getNickname() + i);
+			Photo photo1 = new Photo(post, thumbnailFileRequestDto);
+			Photo photo2 = new Photo(post,  subPhotoFileRequestDto);
 			post.addPhoto(photo1);
 			post.addPhoto(photo2);
 			posts.add(post);

--- a/src/test/java/com/backend/naildp/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/PostLikeRepositoryTest.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Sort;
 import com.backend.naildp.common.Boundary;
 import com.backend.naildp.common.UserRole;
 import com.backend.naildp.dto.auth.LoginRequestDto;
+import com.backend.naildp.dto.post.FileRequestDto;
 import com.backend.naildp.entity.Follow;
 import com.backend.naildp.entity.Photo;
 import com.backend.naildp.entity.Post;
@@ -245,15 +246,18 @@ class PostLikeRepositoryTest {
 	private List<Photo> createSubPhotos(User user, int cnt, Post post) {
 		List<Photo> photos = new ArrayList<>();
 		for (int i = 1; i <= cnt; i++) {
-			Photo photo = new Photo(post, "subUrl-" + user.getNickname() + i, "subName-" + user.getNickname() + i);
+			FileRequestDto fileRequestDto = new FileRequestDto("subName-" + user.getNickname() + i, 1L,
+				"subUrl-" + user.getNickname() + i);
+			Photo photo = new Photo(post, fileRequestDto);
 			photos.add(photo);
 		}
 		return photos;
 	}
 
 	private Photo createThumbnailPhoto(User user, int index, Post post) {
-		return new Photo(post, "thumbnailUrl-" + user.getNickname() + index,
-			"thumbnailName-" + user.getNickname() + index);
+		FileRequestDto fileRequestDto = new FileRequestDto("thumbnailName-" + user.getNickname() + index, 1L,
+			"thumbnailUrl-" + user.getNickname() + index);
+		return new Photo(post, fileRequestDto);
 	}
 
 	private List<PostLike> createPostLikes(List<Post> posts, User likeUser) {

--- a/src/test/java/com/backend/naildp/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/PostLikeRepositoryTest.java
@@ -44,30 +44,24 @@ class PostLikeRepositoryTest {
 
 	@BeforeEach
 	void setup() {
-		User user1 = createTestMember("mj@naver.com", "mj", "0100000", 1L);
-		User user2 = createTestMember("jw@naver.com", "jw", "0109999", 2L);
+		User user1 = createTestMember("user1@naver.com", "user1", "0100000", 1L);
+		User user2 = createTestMember("user2@naver.com", "user2", "0109999", 2L);
 		User writer1 = createTestMember("writer1@naver.com", "writer1", "0101111", 3L);
 		User writer2 = createTestMember("writer2@naver.com", "writer2", "0102222", 4L);
 		User writer3 = createTestMember("writer3@naver.com", "writer3", "0103333", 5L);
 
 		// 게시물 생성
-		List<Post> writerPosts1 = createTestPostWithPhoto(writer1, 5, 5);
-		List<Post> writerPosts2 = createTestPostWithPhoto(writer2, 6, 6);
-		List<Post> writerPosts3 = createTestPostWithPhoto(writer3, 7, 7);
+		List<Post> publicPostsByWriter1 = createTestPostWithPhoto(writer1, 5, 5, Boundary.ALL);
+		List<Post> followPostsByWriter1 = createTestPostWithPhoto(writer1, 5, 5, Boundary.FOLLOW);
+		List<Post> privatePostsByWriter1 = createTestPostWithPhoto(writer1, 5, 5, Boundary.NONE);
+		List<Post> publicPostsByWriter2 = createTestPostWithPhoto(writer2, 6, 6, Boundary.ALL);
+		List<Post> publicPostsByWriter3 = createTestPostWithPhoto(writer3, 7, 7, Boundary.ALL);
 
-		List<PostLike> postLikesByMj = writerPosts1.stream()
-			.map(post -> new PostLike(user1, post))
-			.collect(Collectors.toList());
-		List<PostLike> postLikesByJw1 = writerPosts2.stream()
-			.map(post -> new PostLike(user2, post))
-			.collect(Collectors.toList());
-		List<PostLike> postLikesByJw2 = writerPosts3.stream()
-			.map(post -> new PostLike(user2, post))
-			.collect(Collectors.toList());
-
-		postLikeRepository.saveAllAndFlush(postLikesByMj);
-		postLikeRepository.saveAllAndFlush(postLikesByJw1);
-		postLikeRepository.saveAllAndFlush(postLikesByJw2);
+		postLikeRepository.saveAllAndFlush(createPostLikes(publicPostsByWriter1, user1));
+		postLikeRepository.saveAllAndFlush(createPostLikes(followPostsByWriter1, user1));
+		postLikeRepository.saveAllAndFlush(createPostLikes(privatePostsByWriter1, user1));
+		postLikeRepository.saveAllAndFlush(createPostLikes(publicPostsByWriter2, user2));
+		postLikeRepository.saveAllAndFlush(createPostLikes(publicPostsByWriter3, user2));
 
 		em.clear();
 	}
@@ -76,84 +70,41 @@ class PostLikeRepositoryTest {
 	@Test
 	void validatePostLikeInfo() {
 		//given
-		String nickname = "mj";
+		String nickname = "user1";
+		String writerNickname = "writer1";
+		User user = findUserByNickname(nickname);
+		User writer = findUserByNickname(writerNickname);
 
 		//when
 		List<PostLike> postLikes = postLikeRepository.findAllByUserNickname(nickname);
 
-		List<Post> likedPosts = postLikes.stream().map(PostLike::getPost).toList();
-
-		List<String> writerNicknameList = likedPosts.stream()
-			.map(Post::getUser)
-			.map(User::getNickname)
-			.distinct()
-			.toList();
-
-		List<String> likeUserNicknameList = postLikes.stream()
-			.map(PostLike::getUser)
-			.map(User::getNickname)
-			.distinct()
-			.toList();
-
 		//then
-		assertThat(likedPosts.size()).isEqualTo(5);
-		likedPosts.forEach(post -> assertThat(post.getPhotos().size()).isEqualTo(6));
-
-		assertThat(writerNicknameList.size()).isEqualTo(1);
-		assertThat(writerNicknameList).containsOnly("writer1");
-		assertThat(likeUserNicknameList.size()).isEqualTo(1);
-		assertThat(likeUserNicknameList).containsOnly(nickname);
-
+		assertThat(postLikes).extracting("user").containsOnly(user);
+		assertThat(postLikes).extracting("post").extracting("user").containsOnly(writer);
 	}
 
 	@DisplayName("두명의 게시물을 좋아요한 유저 검증 테스트")
 	@Test
 	void validatePostLikeByUser2() {
 		//given
-		String nickname = "jw";
+		String nickname = "user2";
+		User findUser = findUserByNickname(nickname);
+		User writer2 = findUserByNickname("writer2");
+		User writer3 = findUserByNickname("writer3");
 
 		//when
 		List<PostLike> postLikes = postLikeRepository.findAllByUserNickname(nickname);
 
-		List<Post> likedPosts = postLikes.stream().map(PostLike::getPost).toList();
-		List<Post> likedPostsByWriter2 = postLikes.stream()
-			.map(PostLike::getPost)
-			.filter(post -> post.getUser().getNickname().equals("writer2"))
-			.toList();
-		List<Post> likedPostsByWriter3 = postLikes.stream()
-			.map(PostLike::getPost)
-			.filter(post -> post.getUser().getNickname().equals("writer3"))
-			.toList();
-
-		List<String> writerNicknameList = likedPosts.stream()
-			.map(Post::getUser)
-			.map(User::getNickname)
-			.distinct()
-			.toList();
-
-		List<String> likeUserNicknameList = postLikes.stream()
-			.map(PostLike::getUser)
-			.map(User::getNickname)
-			.distinct()
-			.toList();
-
 		//then
-		assertThat(likedPosts.size()).isEqualTo(likedPostsByWriter2.size() + likedPostsByWriter3.size());
-
-		likedPostsByWriter2.forEach(post -> assertThat(post.getPhotos().size()).isEqualTo(7));
-		likedPostsByWriter3.forEach(post -> assertThat(post.getPhotos().size()).isEqualTo(8));
-
-		assertThat(writerNicknameList.size()).isEqualTo(2);
-		assertThat(writerNicknameList).containsOnly("writer2", "writer3");
-		assertThat(likeUserNicknameList.size()).isEqualTo(1);
-		assertThat(likeUserNicknameList).containsOnly(nickname);
+		assertThat(postLikes).extracting("user").containsOnly(findUser);
+		assertThat(postLikes).extracting("post").extracting("user").containsOnly(writer2, writer3);
 	}
 
-	@DisplayName("사용자 mj 가 좋아요한 모든 게시물 좋아요 취소 테스트")
+	@DisplayName("좋아요한 모든 게시물 좋아요 취소 테스트")
 	@Test
 	void deletePostLike() {
 		//given
-		String nickname = "mj";
+		String nickname = "user1";
 		List<PostLike> postLikes = postLikeRepository.findAllByUserNickname(nickname);
 
 		//when
@@ -162,7 +113,6 @@ class PostLikeRepositoryTest {
 		//then
 		List<PostLike> deletedPostLikes = postLikeRepository.findAllByUserNickname(nickname);
 		assertThat(deletedPostLikes.size()).isEqualTo(0);
-
 	}
 
 	@DisplayName("공개 범위별 좋아요게시물 페이징 조회 테스트")
@@ -171,7 +121,7 @@ class PostLikeRepositoryTest {
 		//given
 		int pageNumber = 0;
 		int pageSize = 20;
-		String nickname = "mj";
+		String nickname = "user1";
 		PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdDate"));
 
 		//when
@@ -183,9 +133,9 @@ class PostLikeRepositoryTest {
 			pageRequest, nickname, Boundary.ALL);
 
 		//then
-		assertThat(pagedPostLikesByBoundaryNotNone).hasSize(5);
-		assertThat(pagedPostLikesByBoundaryNotFollowed).hasSize(5);
-		assertThat(pagedPostLikesByBoundaryNotAll).hasSize(0);
+		assertThat(pagedPostLikesByBoundaryNotNone).hasSize(10);
+		assertThat(pagedPostLikesByBoundaryNotFollowed).hasSize(10);
+		assertThat(pagedPostLikesByBoundaryNotAll).hasSize(10);
 
 		assertThat(pagedPostLikesByBoundaryNotNone.getNumber()).isEqualTo(0);
 		assertThat(pagedPostLikesByBoundaryNotFollowed.getNumber()).isEqualTo(0);
@@ -195,14 +145,13 @@ class PostLikeRepositoryTest {
 		assertThat(pagedPostLikesByBoundaryNotFollowed.getSize()).isEqualTo(20);
 		assertThat(pagedPostLikesByBoundaryNotAll.getSize()).isEqualTo(20);
 
-		assertThat(pagedPostLikesByBoundaryNotNone.getTotalElements()).isEqualTo(5);
-		assertThat(pagedPostLikesByBoundaryNotFollowed.getTotalElements()).isEqualTo(5);
-		assertThat(pagedPostLikesByBoundaryNotAll.getTotalElements()).isEqualTo(0);
+		assertThat(pagedPostLikesByBoundaryNotNone.getTotalElements()).isEqualTo(10);
+		assertThat(pagedPostLikesByBoundaryNotFollowed.getTotalElements()).isEqualTo(10);
+		assertThat(pagedPostLikesByBoundaryNotAll.getTotalElements()).isEqualTo(10);
 
 		assertThat(pagedPostLikesByBoundaryNotNone.getTotalPages()).isEqualTo(1);
 		assertThat(pagedPostLikesByBoundaryNotFollowed.getTotalPages()).isEqualTo(1);
-		assertThat(pagedPostLikesByBoundaryNotAll.getTotalPages()).isEqualTo(0);
-
+		assertThat(pagedPostLikesByBoundaryNotAll.getTotalPages()).isEqualTo(1);
 	}
 
 	private User createTestMember(String email, String nickname, String phoneNumber, Long socialLogInId) {
@@ -214,15 +163,15 @@ class PostLikeRepositoryTest {
 		return user;
 	}
 
-	private List<Post> createTestPostWithPhoto(User user, int postCnt, int subPhotoCnt) {
+	private List<Post> createTestPostWithPhoto(User writer, int postCnt, int subPhotoCnt, Boundary boundary) {
 		List<Photo> photos = new ArrayList<>();
 		List<Post> posts = new ArrayList<>();
 
 		for (int i = 1; i <= postCnt; i++) {
-			Post post = new Post(user, "" + i, 0L, Boundary.ALL, false);
-			Photo thumbnailPhoto = createThumbnailPhoto(user, i, post);
+			Post post = new Post(writer, "" + i, 0L, boundary, false);
+			Photo thumbnailPhoto = createThumbnailPhoto(writer, i, post);
 			post.addPhoto(thumbnailPhoto);
-			List<Photo> subPhotos = createSubPhotos(user, subPhotoCnt, post);
+			List<Photo> subPhotos = createSubPhotos(writer, subPhotoCnt, post);
 			subPhotos.forEach(post::addPhoto);
 
 			posts.add(post);
@@ -252,4 +201,15 @@ class PostLikeRepositoryTest {
 			"thumbnailName-" + user.getNickname() + index);
 	}
 
+	private List<PostLike> createPostLikes(List<Post> posts, User likeUser) {
+		return posts.stream()
+			.map(post -> new PostLike(likeUser, post))
+			.collect(Collectors.toList());
+	}
+
+	private User findUserByNickname(String nickname) {
+		return em.createQuery("select u from Users u where u.nickname = :nickname", User.class)
+			.setParameter("nickname", nickname)
+			.getSingleResult();
+	}
 }

--- a/src/test/java/com/backend/naildp/repository/PostRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/PostRepositoryTest.java
@@ -22,6 +22,7 @@ import com.backend.naildp.common.Boundary;
 import com.backend.naildp.common.UserRole;
 import com.backend.naildp.config.JpaAuditingConfiguration;
 import com.backend.naildp.dto.auth.LoginRequestDto;
+import com.backend.naildp.dto.post.FileRequestDto;
 import com.backend.naildp.entity.Follow;
 import com.backend.naildp.entity.Photo;
 import com.backend.naildp.entity.Post;
@@ -197,8 +198,10 @@ class PostRepositoryTest {
 
 	private void createTestTempSavePostAndPhoto(User user) {
 		Post post = new Post(user, "임시저장 게시물 - " + user.getNickname(), 0L, Boundary.ALL, true);
-		Photo photo1 = new Photo(post, "임시저장 url 1", "임시저장 photo 1-");
-		Photo photo2 = new Photo(post, "임시저장 url 2", "임시저장 photo 2-");
+		FileRequestDto fileRequestDto1 = new FileRequestDto("임시저장 photo 1-", 1L, "임시저장 url 1");
+		FileRequestDto fileRequestDto2 = new FileRequestDto("임시저장 photo 2-", 1L, "임시저장 url 2");
+		Photo photo1 = new Photo(post, fileRequestDto1);
+		Photo photo2 = new Photo(post, fileRequestDto2);
 		post.addPhoto(photo1);
 		post.addPhoto(photo2);
 		posts.add(post);
@@ -209,8 +212,10 @@ class PostRepositoryTest {
 	private void createTestPostWithPhoto(int postCnt, User user, Boundary boundary) {
 		for (int i = 0; i < postCnt; i++) {
 			Post post = new Post(user, "" + i, 0L, boundary, false);
-			Photo photo1 = new Photo(post, "url 1-" + user.getNickname() + i, "photo 1-" + user.getNickname() + i);
-			Photo photo2 = new Photo(post, "url 2-" + user.getNickname() + i, "photo 2-" + user.getNickname() + i);
+			FileRequestDto fileRequestDto1 = new FileRequestDto("photo 1-" + user.getNickname() + i, 1L, "url 1-" + user.getNickname() + i);
+			FileRequestDto fileRequestDto2 = new FileRequestDto("photo 2-" + user.getNickname() + i, 1L, "url 2-" + user.getNickname() + i);
+			Photo photo1 = new Photo(post, fileRequestDto1);
+			Photo photo2 = new Photo(post, fileRequestDto2);
 			post.addPhoto(photo1);
 			post.addPhoto(photo2);
 			posts.add(post);

--- a/src/test/java/com/backend/naildp/service/PostLikeServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/PostLikeServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.backend.naildp.common.Boundary;
 import com.backend.naildp.common.UserRole;
 import com.backend.naildp.dto.auth.LoginRequestDto;
+import com.backend.naildp.dto.post.FileRequestDto;
 import com.backend.naildp.entity.Photo;
 import com.backend.naildp.entity.Post;
 import com.backend.naildp.entity.PostLike;
@@ -125,8 +126,9 @@ class PostLikeServiceTest {
 	private void createTestPostAndPhoto(User writer, int postCnt) {
 		List<Post> postList = new ArrayList<>();
 		for (int i = 0; i < postCnt; i++) {
+			FileRequestDto fileRequestDto = new FileRequestDto("thumbnailPhoto" + i, 1L, "thumbnailURL" + i);
 			Post post = new Post(writer, "content" + i, 0L, Boundary.ALL, false);
-			Photo photo = new Photo(post, "thumbnailURL" + i, "thumbnailPhoto" + i);
+			Photo photo = new Photo(post, fileRequestDto);
 			post.addPhoto(photo);
 
 			em.persist(photo);

--- a/src/test/java/com/backend/naildp/service/PostServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/PostServiceTest.java
@@ -19,6 +19,7 @@ import com.backend.naildp.common.UserRole;
 import com.backend.naildp.dto.auth.LoginRequestDto;
 import com.backend.naildp.dto.home.HomePostResponse;
 import com.backend.naildp.dto.home.PostSummaryResponse;
+import com.backend.naildp.dto.post.FileRequestDto;
 import com.backend.naildp.entity.Archive;
 import com.backend.naildp.entity.ArchivePost;
 import com.backend.naildp.entity.Follow;
@@ -178,8 +179,13 @@ public class PostServiceTest {
 		List<Post> postList = new ArrayList<>();
 		for (int i = 0; i < postCnt; i++) {
 			Post post = new Post(writer, "content" + i, 0L, boundary, false);
-			Photo thumbnailPhoto = new Photo(post, "thumbnailURL" + i, "thumbnailPhoto" + i);
-			Photo subPhoto = new Photo(post, "subPhotoURL" + i, "subPhoto" + i);
+			FileRequestDto thumbnailFileRequestDto =
+				new FileRequestDto("thumbnailPhoto" + i, 1L, "thumbnailUrl" + i);
+			FileRequestDto subPhotoFileRequestDto =
+				new FileRequestDto("subPhoto" + i, 1L, "subPhotoUrl" + i);
+
+			Photo thumbnailPhoto = new Photo(post, thumbnailFileRequestDto);
+			Photo subPhoto = new Photo(post, subPhotoFileRequestDto);
 
 			post.addPhoto(thumbnailPhoto);
 			post.addPhoto(subPhoto);

--- a/src/test/java/com/backend/naildp/service/PostServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/PostServiceTest.java
@@ -42,7 +42,7 @@ import jakarta.persistence.EntityManager;
 public class PostServiceTest {
 
 	@Autowired
-	PostService postService;
+	PostInfoService postInfoService;
 	@Autowired
 	UserRepository userRepository;
 	@Autowired
@@ -93,10 +93,10 @@ public class PostServiceTest {
 		String nickname = "testUser";
 
 		//when
-		PostSummaryResponse firstPostSummaryResponse = postService.homePosts("NEW", firstCallPageSize, -1L, nickname);
+		PostSummaryResponse firstPostSummaryResponse = postInfoService.homePosts("NEW", firstCallPageSize, -1L, nickname);
 		Long oldestPostId = firstPostSummaryResponse.getOldestPostId();
 		System.out.println("oldestPostId = " + oldestPostId);
-		PostSummaryResponse secondPostSummaryResponse = postService.homePosts("NEW", secondCallPageSize, oldestPostId,
+		PostSummaryResponse secondPostSummaryResponse = postInfoService.homePosts("NEW", secondCallPageSize, oldestPostId,
 			nickname);
 
 		Slice<HomePostResponse> firstSummaryList = firstPostSummaryResponse.getPostSummaryList();
@@ -125,7 +125,7 @@ public class PostServiceTest {
 
 		//when
 		System.out.println("첫 페이지");
-		PostSummaryResponse postSummaryResponse = postService.homePosts("NEW", pageSize, cursorPostId, nickname);
+		PostSummaryResponse postSummaryResponse = postInfoService.homePosts("NEW", pageSize, cursorPostId, nickname);
 		Slice<HomePostResponse> responses = postSummaryResponse.getPostSummaryList();
 
 		List<Boolean> savedList = responses.stream().map(HomePostResponse::getSaved).toList();
@@ -151,7 +151,7 @@ public class PostServiceTest {
 		int pageSize = 60;
 
 		//when
-		PostSummaryResponse response = postService.findLikedPost(nickname, pageSize, -1L);
+		PostSummaryResponse response = postInfoService.findLikedPost(nickname, pageSize, -1L);
 		Slice<HomePostResponse> postSummaryList = response.getPostSummaryList();
 
 		//then

--- a/src/test/java/com/backend/naildp/service/PostServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/PostServiceUnitTest.java
@@ -241,6 +241,26 @@ class PostServiceUnitTest {
 		verify(postLikeRepository, never()).findAllByUserNickname(NICKNAME);
 	}
 
+	@DisplayName("익명 사용자 - 최신 게시글 조회 예외 테스트")
+	@Test
+	void recentPostsExceptionByAnonymousUser() {
+		//given
+		long cursorId = -1L;
+		String nickname = "";
+		List<Post> posts = createTestPosts(0);
+		PageRequest pageRequest = createPageRequest(0, PAGE_SIZE, "id");
+		Slice<Post> postSlice = new SliceImpl<>(posts, pageRequest, false);
+
+		when(postRepository.findPostsByBoundaryAndTempSaveFalse(eq(Boundary.ALL), eq(pageRequest)))
+			.thenReturn(postSlice);
+
+		//when & then
+		assertThatThrownBy(() -> postService.homePosts("NEW", PAGE_SIZE, cursorId, nickname))
+			.isInstanceOf(CustomException.class)
+			.hasMessage("최신 게시물이 없습니다.")
+			.extracting("errorCode").isEqualTo(ErrorCode.FILES_NOT_REGISTERED);
+	}
+
 	private List<Post> createTestPosts(int postCnt) {
 		List<Post> posts = new ArrayList<>();
 		for (int i = 0; i < postCnt; i++) {

--- a/src/test/java/com/backend/naildp/service/PostServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/PostServiceUnitTest.java
@@ -41,7 +41,7 @@ import com.backend.naildp.repository.PostRepository;
 class PostServiceUnitTest {
 
 	@InjectMocks
-	PostService postService;
+	PostInfoService postInfoService;
 
 	@Mock
 	PostRepository postRepository;
@@ -83,7 +83,7 @@ class PostServiceUnitTest {
 		when(postLikeRepository.findAllByUserNickname(eq(NICKNAME))).thenReturn(postLikes);
 
 		//when
-		PostSummaryResponse postSummaryResponse = postService.homePosts("NEW", PAGE_SIZE,
+		PostSummaryResponse postSummaryResponse = postInfoService.homePosts("NEW", PAGE_SIZE,
 			cursorPostId, NICKNAME);
 		Slice<HomePostResponse> homePostResponses = postSummaryResponse.getPostSummaryList();
 
@@ -121,7 +121,7 @@ class PostServiceUnitTest {
 		when(postLikeRepository.findAllByUserNickname(NICKNAME)).thenReturn(postLikes);
 
 		//when
-		PostSummaryResponse postSummaryResponse = postService.homePosts("NEW", PAGE_SIZE, cursorPostId, NICKNAME);
+		PostSummaryResponse postSummaryResponse = postInfoService.homePosts("NEW", PAGE_SIZE, cursorPostId, NICKNAME);
 		Slice<HomePostResponse> homePostResponses = postSummaryResponse.getPostSummaryList();
 
 		//then
@@ -153,7 +153,7 @@ class PostServiceUnitTest {
 			.thenReturn(recentPosts);
 
 		//when & then
-		assertThatThrownBy(() -> postService.homePosts("NEW", PAGE_SIZE, cursorPostId, NICKNAME))
+		assertThatThrownBy(() -> postInfoService.homePosts("NEW", PAGE_SIZE, cursorPostId, NICKNAME))
 			.isInstanceOf(CustomException.class)
 			.hasMessage("게시물이 없습니다.");
 
@@ -183,7 +183,7 @@ class PostServiceUnitTest {
 		when(archivePostRepository.findAllByArchiveUserNickname(eq(nickname))).thenReturn(archivePosts);
 
 		//when
-		PostSummaryResponse response = postService.findLikedPost(nickname, pageSize, -1);
+		PostSummaryResponse response = postInfoService.findLikedPost(nickname, pageSize, -1);
 		Slice<HomePostResponse> postSummaryList = response.getPostSummaryList();
 
 		//then
@@ -209,7 +209,7 @@ class PostServiceUnitTest {
 			.thenThrow(new CustomException("좋아요한 게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED));
 
 		//when & then
-		assertThatThrownBy(() -> postService.findLikedPost(nickname, pageSize, -1L))
+		assertThatThrownBy(() -> postInfoService.findLikedPost(nickname, pageSize, -1L))
 			.isInstanceOf(CustomException.class)
 			.hasMessage("좋아요한 게시물이 없습니다.");
 	}
@@ -228,7 +228,7 @@ class PostServiceUnitTest {
 			.thenReturn(pagedPost);
 
 		//when
-		PostSummaryResponse postSummaryResponse = postService.homePosts("NEW", PAGE_SIZE, cursorId, nickname);
+		PostSummaryResponse postSummaryResponse = postInfoService.homePosts("NEW", PAGE_SIZE, cursorId, nickname);
 
 		//then
 		verify(postRepository).findPostsByBoundaryAndTempSaveFalse(Boundary.ALL, pageRequest);
@@ -255,7 +255,7 @@ class PostServiceUnitTest {
 			.thenReturn(postSlice);
 
 		//when & then
-		assertThatThrownBy(() -> postService.homePosts("NEW", PAGE_SIZE, cursorId, nickname))
+		assertThatThrownBy(() -> postInfoService.homePosts("NEW", PAGE_SIZE, cursorId, nickname))
 			.isInstanceOf(CustomException.class)
 			.hasMessage("최신 게시물이 없습니다.")
 			.extracting("errorCode").isEqualTo(ErrorCode.FILES_NOT_REGISTERED);

--- a/src/test/java/com/backend/naildp/service/PostServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/PostServiceUnitTest.java
@@ -30,6 +30,7 @@ import com.backend.naildp.entity.Post;
 import com.backend.naildp.entity.PostLike;
 import com.backend.naildp.entity.User;
 import com.backend.naildp.exception.CustomException;
+import com.backend.naildp.exception.ErrorCode;
 import com.backend.naildp.repository.ArchivePostRepository;
 import com.backend.naildp.repository.FollowRepository;
 import com.backend.naildp.repository.PostLikeRepository;
@@ -192,6 +193,25 @@ class PostServiceUnitTest {
 		verify(postLikeRepository).findPostLikesByFollowing(eq(nickname), anyList(), any(PageRequest.class));
 		verify(postLikeRepository, never()).findPostLikesByIdAndFollowing(anyString(), anyLong(), anyList(),
 			any(PageRequest.class));
+	}
+
+	@DisplayName("좋아요한 게시글 조회 예외 - 좋아요때게시글이 없을 때")
+	@Test
+	void noLikedPostsException() {
+		//given
+		String nickname = "mj";
+		int pageSize = 20;
+		PageRequest pageRequest = createPageRequest(0, pageSize, "id");
+		List<User> followingUsers = new ArrayList<>();
+
+		when(followRepository.findFollowingUserByFollowerNickname(eq(nickname))).thenReturn(followingUsers);
+		when(postLikeRepository.findPostLikesByFollowing(eq(nickname), anyList(), any(PageRequest.class)))
+			.thenThrow(new CustomException("좋아요한 게시물이 없습니다.", ErrorCode.FILES_NOT_REGISTERED));
+
+		//when & then
+		assertThatThrownBy(() -> postService.findLikedPost(nickname, pageSize, -1L))
+			.isInstanceOf(CustomException.class)
+			.hasMessage("좋아요한 게시물이 없습니다.");
 	}
 
 	@DisplayName("익명 사용자 - 최신 게시글 조회 테스트")


### PR DESCRIPTION
### ✅ PR Type

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [x] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- 좋아요한 게시물 조회 API 무한 스크롤 구현 및 리펙토링
- PostService의 조회 로직을 PostInfoService 로 분리

### 📝 상세 내용(Describe your changes)

- 좋아요한 게시물 조회 API
    - 첫 호출 시 offset 기반 페이지네이션으로 PostLike 조회
    - 두번째 호출부터 cursor 기반 페이지네이션으로 PostLike 조회
    - 좋아요한 게시물이 존재하지 않으면 CustomException 예외 처리
- PostInfoService
    - 최신 게시물 조회와 좋아요한 게시물 조회 로직을 이동
 
### 🔗 Issue Number or Link
- #35 