### PR TITLE
[FEATURE] : 댓글 CRUD API

### DIFF
--- a/src/main/java/com/backend/naildp/controller/CommentController.java
+++ b/src/main/java/com/backend/naildp/controller/CommentController.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,5 +30,13 @@ public class CommentController {
 		@AuthenticationPrincipal User user) {
 		Long registeredCommentId = commentService.registerComment(postId, commentRegisterDto, user.getUsername());
 		return ResponseEntity.ok(ApiResponse.successResponse(registeredCommentId, "댓글 등록 성공", 2001));
+	}
+
+	@PatchMapping("/{postId}/comment/{commentId}")
+	ResponseEntity<?> modifyComment(@PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId,
+		@RequestBody CommentRegisterDto commentModifyDto,
+		@AuthenticationPrincipal User user) {
+		Long modifiedCommentId = commentService.modifyComment(postId, commentId, commentModifyDto, user.getUsername());
+		return ResponseEntity.ok(ApiResponse.successResponse(modifiedCommentId, "댓글 등록 성공", 2001));
 	}
 }

--- a/src/main/java/com/backend/naildp/controller/CommentController.java
+++ b/src/main/java/com/backend/naildp/controller/CommentController.java
@@ -1,0 +1,33 @@
+package com.backend.naildp.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.backend.naildp.dto.comment.CommentRegisterDto;
+import com.backend.naildp.exception.ApiResponse;
+import com.backend.naildp.service.CommentService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class CommentController {
+
+	private final CommentService commentService;
+
+	@PostMapping("/{postId}/comment")
+	ResponseEntity<?> createComment(@PathVariable("postId") Long postId,
+		@RequestBody CommentRegisterDto commentRegisterDto,
+		@AuthenticationPrincipal User user) {
+		Long registeredCommentId = commentService.registerComment(postId, commentRegisterDto, user.getUsername());
+		return ResponseEntity.ok(ApiResponse.successResponse(registeredCommentId, "댓글 등록 성공", 2001));
+	}
+}

--- a/src/main/java/com/backend/naildp/controller/CommentController.java
+++ b/src/main/java/com/backend/naildp/controller/CommentController.java
@@ -2,7 +2,7 @@ package com.backend.naildp.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,23 +31,25 @@ public class CommentController {
 	@PostMapping("/{postId}/comment")
 	ResponseEntity<?> createComment(@PathVariable("postId") Long postId,
 		@Valid @RequestBody CommentRegisterDto commentRegisterDto,
-		@AuthenticationPrincipal User user) {
-		Long registeredCommentId = commentService.registerComment(postId, commentRegisterDto, user.getUsername());
+		@AuthenticationPrincipal UserDetails userDetails) {
+		Long registeredCommentId = commentService.registerComment(postId, commentRegisterDto,
+			userDetails.getUsername());
 		return ResponseEntity.ok(ApiResponse.successResponse(registeredCommentId, "댓글 등록 성공", 2001));
 	}
 
 	@PatchMapping("/{postId}/comment/{commentId}")
 	ResponseEntity<?> modifyComment(@PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId,
 		@Valid @RequestBody CommentRegisterDto commentModifyDto,
-		@AuthenticationPrincipal User user) {
-		Long modifiedCommentId = commentService.modifyComment(postId, commentId, commentModifyDto, user.getUsername());
+		@AuthenticationPrincipal UserDetails userDetails) {
+		Long modifiedCommentId = commentService.modifyComment(postId, commentId, commentModifyDto,
+			userDetails.getUsername());
 		return ResponseEntity.ok(ApiResponse.successResponse(modifiedCommentId, "댓글 수정 성공", 2000));
 	}
 
 	@DeleteMapping("/{postId}/comment/{commentId}")
 	ResponseEntity<?> deleteComment(@PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId,
-		@AuthenticationPrincipal User user) {
-		commentService.deleteComment(postId, commentId, user.getUsername());
+		@AuthenticationPrincipal UserDetails userDetails) {
+		commentService.deleteComment(postId, commentId, userDetails.getUsername());
 		return ResponseEntity.ok(ApiResponse.successResponse(null, "댓글 삭제 성공", 2000));
 	}
 

--- a/src/main/java/com/backend/naildp/controller/CommentController.java
+++ b/src/main/java/com/backend/naildp/controller/CommentController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.backend.naildp.dto.comment.CommentRegisterDto;
@@ -47,5 +48,13 @@ public class CommentController {
 		@AuthenticationPrincipal User user) {
 		commentService.deleteComment(postId, commentId, user.getUsername());
 		return ResponseEntity.ok(ApiResponse.successResponse(null, "댓글 삭제 성공", 2000));
+	}
+
+	@GetMapping("/postId}/comment")
+	ResponseEntity<?> findComments(@PathVariable("postId") Long postId,
+		@RequestParam(required = false, defaultValue = "20", value = "size") int size,
+		@RequestParam(required = false, defaultValue = "-1", value = "cursorId") long cursorId) {
+		commentService.findComments(postId, size, cursorId);
+		return null;
 	}
 }

--- a/src/main/java/com/backend/naildp/controller/CommentController.java
+++ b/src/main/java/com/backend/naildp/controller/CommentController.java
@@ -16,6 +16,7 @@ import com.backend.naildp.dto.comment.CommentRegisterDto;
 import com.backend.naildp.exception.ApiResponse;
 import com.backend.naildp.service.CommentService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,7 +28,7 @@ public class CommentController {
 
 	@PostMapping("/{postId}/comment")
 	ResponseEntity<?> createComment(@PathVariable("postId") Long postId,
-		@RequestBody CommentRegisterDto commentRegisterDto,
+		@Valid @RequestBody CommentRegisterDto commentRegisterDto,
 		@AuthenticationPrincipal User user) {
 		Long registeredCommentId = commentService.registerComment(postId, commentRegisterDto, user.getUsername());
 		return ResponseEntity.ok(ApiResponse.successResponse(registeredCommentId, "댓글 등록 성공", 2001));
@@ -35,16 +36,16 @@ public class CommentController {
 
 	@PatchMapping("/{postId}/comment/{commentId}")
 	ResponseEntity<?> modifyComment(@PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId,
-		@RequestBody CommentRegisterDto commentModifyDto,
+		@Valid @RequestBody CommentRegisterDto commentModifyDto,
 		@AuthenticationPrincipal User user) {
 		Long modifiedCommentId = commentService.modifyComment(postId, commentId, commentModifyDto, user.getUsername());
-		return ResponseEntity.ok(ApiResponse.successResponse(modifiedCommentId, "댓글 수정 성공", 2001));
+		return ResponseEntity.ok(ApiResponse.successResponse(modifiedCommentId, "댓글 수정 성공", 2000));
 	}
 
 	@DeleteMapping("/{postId}/comment/{commentId}")
 	ResponseEntity<?> deleteComment(@PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId,
 		@AuthenticationPrincipal User user) {
 		commentService.deleteComment(postId, commentId, user.getUsername());
-		return ResponseEntity.ok(ApiResponse.successResponse(null, "댓글 삭제 성공", 2001));
+		return ResponseEntity.ok(ApiResponse.successResponse(null, "댓글 삭제 성공", 2000));
 	}
 }

--- a/src/main/java/com/backend/naildp/controller/CommentController.java
+++ b/src/main/java/com/backend/naildp/controller/CommentController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.backend.naildp.dto.comment.CommentRegisterDto;
+import com.backend.naildp.dto.comment.CommentSummaryResponse;
 import com.backend.naildp.exception.ApiResponse;
 import com.backend.naildp.service.CommentService;
 
@@ -54,7 +55,7 @@ public class CommentController {
 	ResponseEntity<?> findComments(@PathVariable("postId") Long postId,
 		@RequestParam(required = false, defaultValue = "20", value = "size") int size,
 		@RequestParam(required = false, defaultValue = "-1", value = "cursorId") long cursorId) {
-		commentService.findComments(postId, size, cursorId);
-		return null;
+		CommentSummaryResponse response = commentService.findComments(postId, size, cursorId);
+		return ResponseEntity.ok(ApiResponse.successResponse(response, "댓글 조회 성공", 2000));
 	}
 }

--- a/src/main/java/com/backend/naildp/controller/CommentController.java
+++ b/src/main/java/com/backend/naildp/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.backend.naildp.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,6 +38,13 @@ public class CommentController {
 		@RequestBody CommentRegisterDto commentModifyDto,
 		@AuthenticationPrincipal User user) {
 		Long modifiedCommentId = commentService.modifyComment(postId, commentId, commentModifyDto, user.getUsername());
-		return ResponseEntity.ok(ApiResponse.successResponse(modifiedCommentId, "댓글 등록 성공", 2001));
+		return ResponseEntity.ok(ApiResponse.successResponse(modifiedCommentId, "댓글 수정 성공", 2001));
+	}
+
+	@DeleteMapping("/{postId}/comment/{commentId}")
+	ResponseEntity<?> deleteComment(@PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId,
+		@AuthenticationPrincipal User user) {
+		commentService.deleteComment(postId, commentId, user.getUsername());
+		return ResponseEntity.ok(ApiResponse.successResponse(null, "댓글 삭제 성공", 2001));
 	}
 }

--- a/src/main/java/com/backend/naildp/controller/CommentController.java
+++ b/src/main/java/com/backend/naildp/controller/CommentController.java
@@ -50,7 +50,7 @@ public class CommentController {
 		return ResponseEntity.ok(ApiResponse.successResponse(null, "댓글 삭제 성공", 2000));
 	}
 
-	@GetMapping("/postId}/comment")
+	@GetMapping("/{postId}/comment")
 	ResponseEntity<?> findComments(@PathVariable("postId") Long postId,
 		@RequestParam(required = false, defaultValue = "20", value = "size") int size,
 		@RequestParam(required = false, defaultValue = "-1", value = "cursorId") long cursorId) {

--- a/src/main/java/com/backend/naildp/controller/HomeController.java
+++ b/src/main/java/com/backend/naildp/controller/HomeController.java
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class HomeController {
 
-	// private final PostService postService;
 	private final PostInfoService postInfoService;
 
 	@GetMapping("/home")

--- a/src/main/java/com/backend/naildp/controller/PostController.java
+++ b/src/main/java/com/backend/naildp/controller/PostController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -85,8 +86,8 @@ public class PostController {
 
 	@GetMapping("/{postId}")
 	ResponseEntity<ApiResponse<?>> postDetails(@PathVariable("postId") Long postId,
-		@AuthenticationPrincipal User user) {
-		PostInfoResponse postInfoResponse = postService.postInfo(user.getUsername(), postId);
+		@AuthenticationPrincipal UserDetails userDetails) {
+		PostInfoResponse postInfoResponse = postService.postInfo(userDetails.getUsername(), postId);
 		return ResponseEntity.ok(ApiResponse.successResponse(postInfoResponse, "특정 게시물 상세정보 조회", 2000));
 	}
 

--- a/src/main/java/com/backend/naildp/dto/comment/CommentInfoResponse.java
+++ b/src/main/java/com/backend/naildp/dto/comment/CommentInfoResponse.java
@@ -21,6 +21,7 @@ public class CommentInfoResponse {
 	private String commentUserNickname;
 	private LocalDateTime commentDate;
 	private long likeCount;
+	private long replyCount;
 
 	public static CommentInfoResponse of(Comment comment) {
 		return CommentInfoResponse.builder()
@@ -29,6 +30,8 @@ public class CommentInfoResponse {
 			.profileUrl(comment.getUser().getThumbnailUrl())
 			.commentUserNickname(comment.getUser().getNickname())
 			.commentDate(comment.getCreatedDate())
+			.likeCount(comment.getLikeCount())
+			.replyCount(0)
 			.build();
 	}
 }

--- a/src/main/java/com/backend/naildp/dto/comment/CommentInfoResponse.java
+++ b/src/main/java/com/backend/naildp/dto/comment/CommentInfoResponse.java
@@ -1,0 +1,34 @@
+package com.backend.naildp.dto.comment;
+
+import java.time.LocalDateTime;
+
+import com.backend.naildp.entity.Comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentInfoResponse {
+
+	private long commentId;
+	private String commentContent;
+	private String profileUrl;
+	private String commentUserNickname;
+	private LocalDateTime commentDate;
+	private long likeCount;
+
+	public static CommentInfoResponse of(Comment comment) {
+		return CommentInfoResponse.builder()
+			.commentId(comment.getId())
+			.commentContent(comment.getCommentContent())
+			.profileUrl("")
+			.commentUserNickname(comment.getUser().getNickname())
+			.commentDate(comment.getCreatedDate())
+			.build();
+	}
+}

--- a/src/main/java/com/backend/naildp/dto/comment/CommentInfoResponse.java
+++ b/src/main/java/com/backend/naildp/dto/comment/CommentInfoResponse.java
@@ -26,7 +26,7 @@ public class CommentInfoResponse {
 		return CommentInfoResponse.builder()
 			.commentId(comment.getId())
 			.commentContent(comment.getCommentContent())
-			.profileUrl("")
+			.profileUrl(comment.getUser().getThumbnailUrl())
 			.commentUserNickname(comment.getUser().getNickname())
 			.commentDate(comment.getCreatedDate())
 			.build();

--- a/src/main/java/com/backend/naildp/dto/comment/CommentRegisterDto.java
+++ b/src/main/java/com/backend/naildp/dto/comment/CommentRegisterDto.java
@@ -1,0 +1,16 @@
+package com.backend.naildp.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentRegisterDto {
+
+	@NotBlank(message = "댓글을 입력해주세요")
+	private String commentContent;
+}

--- a/src/main/java/com/backend/naildp/dto/comment/CommentSummaryResponse.java
+++ b/src/main/java/com/backend/naildp/dto/comment/CommentSummaryResponse.java
@@ -1,0 +1,23 @@
+package com.backend.naildp.dto.comment;
+
+import java.util.ArrayList;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentSummaryResponse {
+
+	private Long cursorId;
+	private Slice<CommentInfoResponse> contents;
+
+	public static CommentSummaryResponse createEmptyResponse() {
+		return new CommentSummaryResponse(-1L, new SliceImpl<>(new ArrayList<>()));
+	}
+}

--- a/src/main/java/com/backend/naildp/entity/Comment.java
+++ b/src/main/java/com/backend/naildp/entity/Comment.java
@@ -1,5 +1,11 @@
 package com.backend.naildp.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Formula;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,6 +14,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,8 +37,14 @@ public class Comment extends BaseEntity {
 	@JoinColumn(name = "post_id")
 	private Post post;
 
+	@OneToMany(mappedBy = "comment")
+	private List<CommentLike> commentLikes = new ArrayList<>();
+
 	@Column(nullable = false)
 	private String commentContent;
+
+	@Formula("(select count(*) from comment_like where comment_like.comment_id = comment_id)")
+	private long likeCount;
 
 	public Comment(User user, Post post, String commentContent) {
 		this.user = user;

--- a/src/main/java/com/backend/naildp/entity/Comment.java
+++ b/src/main/java/com/backend/naildp/entity/Comment.java
@@ -38,4 +38,12 @@ public class Comment extends BaseEntity {
 		this.post = post;
 		this.commentContent = commentContent;
 	}
+
+	public void modifyContent(String commentContent) {
+		this.commentContent = commentContent;
+	}
+
+	public boolean writtenBy(String username) {
+		return user.equalsNickname(username);
+	}
 }

--- a/src/main/java/com/backend/naildp/entity/Comment.java
+++ b/src/main/java/com/backend/naildp/entity/Comment.java
@@ -9,8 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -45,7 +43,7 @@ public class Comment extends BaseEntity {
 		this.commentContent = commentContent;
 	}
 
-	public boolean writtenBy(String username) {
-		return user.equalsNickname(username);
+	public boolean notRegisteredBy(String username) {
+		return !user.equalsNickname(username);
 	}
 }

--- a/src/main/java/com/backend/naildp/entity/Comment.java
+++ b/src/main/java/com/backend/naildp/entity/Comment.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/backend/naildp/entity/CommentLike.java
+++ b/src/main/java/com/backend/naildp/entity/CommentLike.java
@@ -26,7 +26,11 @@ public class CommentLike {
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "post_id")
+	@JoinColumn(name = "comment_id")
 	private Comment comment;
 
+	public CommentLike(User user, Comment comment) {
+		this.user = user;
+		this.comment = comment;
+	}
 }

--- a/src/main/java/com/backend/naildp/entity/Post.java
+++ b/src/main/java/com/backend/naildp/entity/Post.java
@@ -96,4 +96,19 @@ public class Post extends BaseEntity {
 		this.postLikes.add(postLike);
 	}
 
+	public void addComment(Comment comment) {
+		this.comments.add(comment);
+	}
+
+	public boolean isTempSaved() {
+		return this.tempSave;
+	}
+
+	public boolean isClosed() {
+		return this.boundary == Boundary.NONE;
+	}
+
+	public boolean isOpenedForFollower() {
+		return this.boundary == Boundary.FOLLOW;
+	}
 }

--- a/src/main/java/com/backend/naildp/entity/Post.java
+++ b/src/main/java/com/backend/naildp/entity/Post.java
@@ -111,4 +111,8 @@ public class Post extends BaseEntity {
 	public boolean isOpenedForFollower() {
 		return this.boundary == Boundary.FOLLOW;
 	}
+
+	public void deleteComment(Comment comment) {
+		this.comments.remove(comment);
+	}
 }

--- a/src/main/java/com/backend/naildp/entity/Post.java
+++ b/src/main/java/com/backend/naildp/entity/Post.java
@@ -40,15 +40,19 @@ public class Post extends BaseEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
+	// @Builder.Default
 	@OneToMany(mappedBy = "post")
 	private List<Photo> photos = new ArrayList<>();
 
+	@Builder.Default
 	@OneToMany(mappedBy = "post")
 	private List<Comment> comments = new ArrayList<>();
 
+	// @Builder.Default
 	@OneToMany(mappedBy = "post")
 	private List<PostLike> postLikes = new ArrayList<>();
 
+	// @Builder.Default
 	@OneToMany(mappedBy = "post")
 	private List<TagPost> tagPosts = new ArrayList<>();
 

--- a/src/main/java/com/backend/naildp/entity/Post.java
+++ b/src/main/java/com/backend/naildp/entity/Post.java
@@ -40,7 +40,7 @@ public class Post extends BaseEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	// @Builder.Default
+	@Builder.Default
 	@OneToMany(mappedBy = "post")
 	private List<Photo> photos = new ArrayList<>();
 
@@ -48,11 +48,11 @@ public class Post extends BaseEntity {
 	@OneToMany(mappedBy = "post")
 	private List<Comment> comments = new ArrayList<>();
 
-	// @Builder.Default
+	@Builder.Default
 	@OneToMany(mappedBy = "post")
 	private List<PostLike> postLikes = new ArrayList<>();
 
-	// @Builder.Default
+	@Builder.Default
 	@OneToMany(mappedBy = "post")
 	private List<TagPost> tagPosts = new ArrayList<>();
 

--- a/src/main/java/com/backend/naildp/exception/ErrorCode.java
+++ b/src/main/java/com/backend/naildp/exception/ErrorCode.java
@@ -28,7 +28,9 @@ public enum ErrorCode {
 
 	FILES_NOT_REGISTERED(4005),
 
-	USER_MISMATCH(4006);
+	USER_MISMATCH(4006),
+
+	COMMENT_AUTHORITY(4007);
 	// EXPIRED_JWT("401_1", "JWT 시간이 만료되었습니다."),
 	// AUTHENTICATION_FAILURE_JWT("401_2", "올바른 JWT 정보가 아닙니다.");
 	private final int errorCode;

--- a/src/main/java/com/backend/naildp/repository/CommentRepository.java
+++ b/src/main/java/com/backend/naildp/repository/CommentRepository.java
@@ -1,7 +1,10 @@
 package com.backend.naildp.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +18,17 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	@Query("select c from Comment c join fetch c.post join fetch c.user where c.id = :id")
 	Optional<Comment> findCommentAndPostAndUser(@Param("id") Long id);
+
+	@Query("select c from Comment c join fetch c.user where c.post.id = :postId")
+	Slice<Comment> findCommentsByPostId(@Param("postId") Long postId, PageRequest pageRequest);
+
+	@Query("select c from Comment c join fetch c.user where c.post.id = :postId"
+		+ " and ((c.likeCount <= :likeCount and c.id < :commentId) or c.likeCount < :likeCount)")
+	Slice<Comment> findCommentsByPostIdAndIdBefore(@Param("postId") Long postId,
+		@Param("commentId") Long commentId,
+		@Param("likeCount") Long likeCount,
+		PageRequest pageRequest);
+
+	@Query("select c.likeCount from Comment c where c.id = :commentId")
+	long countLikesById(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/backend/naildp/repository/CommentRepository.java
+++ b/src/main/java/com/backend/naildp/repository/CommentRepository.java
@@ -1,6 +1,10 @@
 package com.backend.naildp.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.backend.naildp.entity.Comment;
 import com.backend.naildp.entity.Post;
@@ -8,4 +12,7 @@ import com.backend.naildp.entity.Post;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	long countAllByPost(Post post);
+
+	@Query("select c from Comment c join fetch c.post join fetch c.user where c.id = :id")
+	Optional<Comment> findCommentAndPostAndUser(@Param("id") Long id);
 }

--- a/src/main/java/com/backend/naildp/repository/PostRepository.java
+++ b/src/main/java/com/backend/naildp/repository/PostRepository.java
@@ -38,6 +38,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	@Query("select p from Post p join fetch p.user u where p.id = :id and p.tempSave = false")
 	Optional<Post> findPostAndWriterById(@Param("id") Long postId);
 
+	@Query("select p from Post p join fetch p.user u where p.id = :id")
+	Optional<Post> findPostAndUser(@Param("id") Long postId);
+
 	Optional<Post> findPostByTempSaveIsTrueAndUser(User user);
 
 }

--- a/src/main/java/com/backend/naildp/service/CommentService.java
+++ b/src/main/java/com/backend/naildp/service/CommentService.java
@@ -1,0 +1,49 @@
+package com.backend.naildp.service;
+
+import org.springframework.stereotype.Service;
+
+import com.backend.naildp.dto.comment.CommentRegisterDto;
+import com.backend.naildp.entity.Comment;
+import com.backend.naildp.entity.Post;
+import com.backend.naildp.entity.User;
+import com.backend.naildp.exception.CustomException;
+import com.backend.naildp.exception.ErrorCode;
+import com.backend.naildp.repository.CommentRepository;
+import com.backend.naildp.repository.FollowRepository;
+import com.backend.naildp.repository.PostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+	private final PostRepository postRepository;
+	private final CommentRepository commentRepository;
+	private final FollowRepository followRepository;
+
+	public Long registerComment(Long postId, CommentRegisterDto commentRegisterDto, String username) {
+		Post post = postRepository.findPostAndUser(postId)
+			.orElseThrow(() -> new CustomException("해당 포스트에 댓글을 등록할 수 없습니다. 다시 시도해주세요", ErrorCode.NOT_FOUND));
+		User user = post.getUser();
+
+		//post 에 댓글 달 수 있는지 확인
+		//1. tempSave = false 인지
+		//2. boundary 가 All 이거나 boundary 가 Follow 면서 username 이 팔로우 하고 있는지까지 확인 필요
+		if (post.isTempSaved()) {
+			throw new CustomException("접근 불가", null);
+		}
+		if (post.isClosed()) {
+			throw new CustomException("접근 불가", null);
+		}
+		if (post.isOpenedForFollower() && followRepository.existsByFollowerNicknameAndFollowing(username, user)) {
+			throw new CustomException("접근 불가", null);
+		}
+
+		//comment 생성 및 저장
+		Comment comment = new Comment(user, post, commentRegisterDto.getCommentContent());
+		post.addComment(comment);
+
+		return commentRepository.save(comment).getId();
+	}
+}

--- a/src/main/java/com/backend/naildp/service/CommentService.java
+++ b/src/main/java/com/backend/naildp/service/CommentService.java
@@ -57,7 +57,7 @@ public class CommentService {
 		Comment comment = commentRepository.findCommentAndPostAndUser(commentId)
 			.orElseThrow(() -> new CustomException("댓글을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
 
-		if (!comment.writtenBy(username)) {
+		if (comment.notRegisteredBy(username)) {
 			throw new CustomException("댓글은 작성자만 수정할 수 있습니다.", ErrorCode.COMMENT_AUTHORITY);
 		}
 
@@ -71,7 +71,7 @@ public class CommentService {
 		Comment comment = commentRepository.findCommentAndPostAndUser(commentId)
 			.orElseThrow(() -> new CustomException("댓글을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
 
-		if (!comment.writtenBy(username)) {
+		if (comment.notRegisteredBy(username)) {
 			throw new CustomException("댓글은 작성자만 삭제할 수 있습니다.", ErrorCode.COMMENT_AUTHORITY);
 		}
 

--- a/src/main/java/com/backend/naildp/service/CommentService.java
+++ b/src/main/java/com/backend/naildp/service/CommentService.java
@@ -41,7 +41,7 @@ public class CommentService {
 			throw new CustomException("비공개 게시물에는 댓글을 등록할 수 없습니다.", ErrorCode.COMMENT_AUTHORITY);
 		}
 
-		if (post.isOpenedForFollower() && followRepository.existsByFollowerNicknameAndFollowing(username, user)) {
+		if (post.isOpenedForFollower() && !followRepository.existsByFollowerNicknameAndFollowing(username, user)) {
 			throw new CustomException("팔로워만 댓글을 등록할 수 있습니다.", ErrorCode.COMMENT_AUTHORITY);
 		}
 

--- a/src/main/java/com/backend/naildp/service/CommentService.java
+++ b/src/main/java/com/backend/naildp/service/CommentService.java
@@ -65,4 +65,19 @@ public class CommentService {
 
 		return comment.getId();
 	}
+
+	@Transactional
+	public void deleteComment(Long postId, Long commentId, String username) {
+		Comment comment = commentRepository.findCommentAndPostAndUser(commentId)
+			.orElseThrow(() -> new CustomException("댓글을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
+
+		if (!comment.writtenBy(username)) {
+			throw new CustomException("댓글은 작성자만 삭제할 수 있습니다.", ErrorCode.COMMENT_AUTHORITY);
+		}
+
+		Post post = comment.getPost();
+		post.deleteComment(comment);
+
+		commentRepository.delete(comment);
+	}
 }

--- a/src/main/java/com/backend/naildp/service/CommentService.java
+++ b/src/main/java/com/backend/naildp/service/CommentService.java
@@ -17,6 +17,7 @@ import com.backend.naildp.exception.ErrorCode;
 import com.backend.naildp.repository.CommentRepository;
 import com.backend.naildp.repository.FollowRepository;
 import com.backend.naildp.repository.PostRepository;
+import com.backend.naildp.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,6 +29,7 @@ public class CommentService {
 	private final PostRepository postRepository;
 	private final CommentRepository commentRepository;
 	private final FollowRepository followRepository;
+	private final UserRepository userRepository;
 
 	@Transactional
 	public Long registerComment(Long postId, CommentRegisterDto commentRegisterDto, String username) {
@@ -51,7 +53,9 @@ public class CommentService {
 		}
 
 		//comment 생성 및 저장
-		Comment comment = new Comment(user, post, commentRegisterDto.getCommentContent());
+		User commenter = userRepository.findByNickname(username)
+			.orElseThrow(() -> new CustomException("다시 시도해주세요.", ErrorCode.NOT_FOUND));
+		Comment comment = new Comment(commenter, post, commentRegisterDto.getCommentContent());
 		post.addComment(comment);
 
 		return commentRepository.save(comment).getId();

--- a/src/main/java/com/backend/naildp/service/CommentService.java
+++ b/src/main/java/com/backend/naildp/service/CommentService.java
@@ -31,13 +31,15 @@ public class CommentService {
 		//1. tempSave = false 인지
 		//2. boundary 가 All 이거나 boundary 가 Follow 면서 username 이 팔로우 하고 있는지까지 확인 필요
 		if (post.isTempSaved()) {
-			throw new CustomException("접근 불가", null);
+			throw new CustomException("임시저장한 게시물에는 댓글을 등록할 수 없습니다.", ErrorCode.COMMENT_AUTHORITY);
 		}
+
 		if (post.isClosed()) {
-			throw new CustomException("접근 불가", null);
+			throw new CustomException("비공개 게시물에는 댓글을 등록할 수 없습니다.", ErrorCode.COMMENT_AUTHORITY);
 		}
+
 		if (post.isOpenedForFollower() && followRepository.existsByFollowerNicknameAndFollowing(username, user)) {
-			throw new CustomException("접근 불가", null);
+			throw new CustomException("팔로워만 댓글을 등록할 수 있습니다.", ErrorCode.COMMENT_AUTHORITY);
 		}
 
 		//comment 생성 및 저장

--- a/src/test/java/com/backend/naildp/controller/CommentControllerUnitTest.java
+++ b/src/test/java/com/backend/naildp/controller/CommentControllerUnitTest.java
@@ -1,0 +1,162 @@
+package com.backend.naildp.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.backend.naildp.dto.comment.CommentRegisterDto;
+import com.backend.naildp.exception.ApiResponse;
+import com.backend.naildp.service.CommentService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CommentControllerUnitTest {
+
+	@Autowired
+	MockMvc mvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@MockBean
+	CommentService commentService;
+
+	@Test
+	@WithMockUser(username = "testUser", roles = {"USER"})
+	void 잘못된_형식으로_댓글_작성시_예외_발생() throws Exception {
+		//given
+		String message = "댓글을 입력해주세요";
+		ApiResponse<?> apiResponse = ApiResponse.of(HttpStatus.BAD_REQUEST.value());
+		apiResponse.setMessage(message);
+
+		String nullRequest = objectMapper.writeValueAsString(new CommentRegisterDto());
+		String emptyStringRequest = objectMapper.writeValueAsString(new CommentRegisterDto(""));
+		String blankStringRequest = objectMapper.writeValueAsString(new CommentRegisterDto("  "));
+
+		//when
+		ResultActions nullResultActions = mvc.perform(
+			post("/posts/{postId}/comment", 1L)
+				.content(nullRequest)
+				.contentType(MediaType.APPLICATION_JSON));
+		ResultActions emptyStringResultActions = mvc.perform(
+			post("/posts/{postId}/comment", 1L)
+				.content(emptyStringRequest)
+				.contentType(MediaType.APPLICATION_JSON));
+		ResultActions blankResultActions = mvc.perform(
+			post("/posts/{postId}/comment", 1L)
+				.content(blankStringRequest)
+				.contentType(MediaType.APPLICATION_JSON));
+
+		//then
+		nullResultActions
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()));
+		emptyStringResultActions
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()));
+		blankResultActions
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()));
+	}
+
+	@Test
+	@WithMockUser(username = "testUser", roles = {"USER"})
+	void 댓글_작성_API_테스트() throws Exception {
+		//given
+		Long registeredCommentId = 1L;
+		ApiResponse<Long> apiResponse = ApiResponse.successResponse(registeredCommentId, "댓글 등록 성공", 2001);
+
+		CommentRegisterDto commentRegisterDto = new CommentRegisterDto("댓글");
+		String request = objectMapper.writeValueAsString(commentRegisterDto);
+
+		//when
+		ResultActions resultActions = mvc.perform(
+			post("/posts/{postId}/comment", 1L)
+				.content(request)
+				.contentType(MediaType.APPLICATION_JSON));
+
+		//then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()));
+	}
+
+	@Test
+	@WithMockUser(username = "testUser", roles = {"USER"})
+	void 잘못된_형식으로_댓글_수정시_예외_발생() throws Exception {
+		String message = "댓글을 입력해주세요";
+		ApiResponse<?> apiResponse = ApiResponse.of(HttpStatus.BAD_REQUEST.value());
+		apiResponse.setMessage(message);
+
+		String nullRequest = objectMapper.writeValueAsString(new CommentRegisterDto());
+		String emptyStringRequest = objectMapper.writeValueAsString(new CommentRegisterDto(""));
+		String blankStringRequest = objectMapper.writeValueAsString(new CommentRegisterDto("  "));
+
+		//when
+		ResultActions nullResultActions = mvc.perform(
+			patch("/posts/{postId}/comment/{commentId}", 1L, 2L)
+				.content(nullRequest)
+				.contentType(MediaType.APPLICATION_JSON));
+		ResultActions emptyStringResultActions = mvc.perform(
+			patch("/posts/{postId}/comment/{commentId}", 1L, 2L)
+				.content(emptyStringRequest)
+				.contentType(MediaType.APPLICATION_JSON));
+		ResultActions blankResultActions = mvc.perform(
+			patch("/posts/{postId}/comment/{commentId}", 1L, 2L)
+				.content(blankStringRequest)
+				.contentType(MediaType.APPLICATION_JSON));
+
+		//then
+		nullResultActions
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()));
+		emptyStringResultActions
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()));
+		blankResultActions
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()));
+	}
+
+	@Test
+	@WithMockUser(username = "testUser", roles = {"USER"})
+	void 댓글_수정_API_테스트() throws Exception {
+		//given
+		Long modifiedCommentId = 1L;
+		ApiResponse<Long> apiResponse = ApiResponse.successResponse(modifiedCommentId, "댓글 수정 성공", 2000);
+
+		CommentRegisterDto commentModifyDto = new CommentRegisterDto("수정 댓글");
+		String request = objectMapper.writeValueAsString(commentModifyDto);
+
+		//when
+		ResultActions resultActions = mvc.perform(
+			patch("/posts/{postId}/comment/{commentId}", 1L, 2L)
+				.content(request)
+				.contentType(MediaType.APPLICATION_JSON));
+
+		//then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(apiResponse.getMessage()))
+			.andExpect(jsonPath("$.code").value(apiResponse.getCode()));
+	}
+}

--- a/src/test/java/com/backend/naildp/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/CommentRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.backend.naildp.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.backend.naildp.common.Boundary;
+import com.backend.naildp.common.UserRole;
+import com.backend.naildp.config.JpaAuditingConfiguration;
+import com.backend.naildp.entity.Comment;
+import com.backend.naildp.entity.CommentLike;
+import com.backend.naildp.entity.Post;
+import com.backend.naildp.entity.User;
+
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@DataJpaTest
+@Import({JpaAuditingConfiguration.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CommentRepositoryTest {
+
+	@Autowired
+	CommentRepository commentRepository;
+	@Autowired
+	EntityManager em;
+
+	@Test
+	void 댓글_좋아요_개수_세기() {
+		//given
+		User user = User.builder().nickname("nickname").phoneNumber("pn").agreement(true).role(UserRole.USER).build();
+		User commentLiker = User.builder().nickname("commentLiker").phoneNumber("pn").agreement(true).role(UserRole.USER).build();
+		Post post = Post.builder().user(user).postContent("content").boundary(Boundary.ALL).tempSave(false).build();
+		Comment comment = new Comment(user, post, "comment");
+
+		em.persist(user);
+		em.persist(commentLiker);
+		em.persist(post);
+		em.persist(comment);
+
+		int likeCnt = 5;
+		for (int i = 0; i < likeCnt; i++) {
+			em.persist(new CommentLike(commentLiker, comment));
+		}
+
+		em.flush();
+		em.clear();
+
+		//when
+		long commentLikeCount = commentRepository.countLikesById(comment.getId());
+
+		//then
+		assertEquals(likeCnt, commentLikeCount);
+	}
+}

--- a/src/test/java/com/backend/naildp/service/CommentServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/CommentServiceTest.java
@@ -1,0 +1,121 @@
+package com.backend.naildp.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.backend.naildp.common.Boundary;
+import com.backend.naildp.common.UserRole;
+import com.backend.naildp.dto.comment.CommentInfoResponse;
+import com.backend.naildp.dto.comment.CommentSummaryResponse;
+import com.backend.naildp.entity.Comment;
+import com.backend.naildp.entity.Post;
+import com.backend.naildp.entity.User;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+@Transactional
+class CommentServiceTest {
+
+	@Autowired
+	CommentService commentService;
+
+	@Autowired
+	EntityManager em;
+
+	final int COMMENT_CNT = 60;
+	final long FIRST_CURSOR_ID = -1L;
+
+	@BeforeEach
+	void setup() {
+		User user = User.builder().nickname("user").phoneNumber("pn").agreement(true).role(UserRole.USER).build();
+		em.persist(user);
+		User commenter = User.builder().nickname("user").phoneNumber("pn").agreement(true).role(UserRole.USER).build();
+		em.persist(commenter);
+		User noCommentUser = User.builder()
+			.nickname("noCommentUser")
+			.phoneNumber("pn")
+			.agreement(true)
+			.role(UserRole.USER)
+			.build();
+		em.persist(noCommentUser);
+
+		Post post = Post.builder().user(user).postContent("content").tempSave(false).boundary(Boundary.ALL).build();
+		em.persist(post);
+		Post noCommentPost = Post.builder()
+			.user(noCommentUser)
+			.postContent("noComment")
+			.tempSave(false)
+			.boundary(Boundary.ALL)
+			.build();
+		em.persist(noCommentPost);
+
+		for (int i = 0; i < COMMENT_CNT; i++) {
+			Comment comment = new Comment(commenter, post, "comment");
+			em.persist(comment);
+		}
+	}
+
+	@Test
+	void 댓글_첫번째_페이지_조회_테스트() {
+		//given
+		int pageSize = COMMENT_CNT - 1;
+		Post post = em.createQuery("select p from Post p where p.user.nickname = :nickname", Post.class)
+			.setParameter("nickname", "user")
+			.getSingleResult();
+
+		//when
+		CommentSummaryResponse response = commentService.findComments(post.getId(), pageSize, FIRST_CURSOR_ID);
+		Slice<CommentInfoResponse> contents = response.getContents();
+
+		//then
+		assertNotEquals(-1L, response.getCursorId());
+		assertTrue(contents.hasNext());
+		assertEquals(pageSize, contents.getNumberOfElements());
+		Assertions.assertThat(contents).extracting(CommentInfoResponse::getProfileUrl).containsOnly("default");
+	}
+
+	@Test
+	void 댓글_조회_테스트_댓글수보다_페이지가_클때() {
+		//given
+		int pageSize = COMMENT_CNT + 1;
+		Post post = em.createQuery("select p from Post p where p.user.nickname = :nickname", Post.class)
+			.setParameter("nickname", "user")
+			.getSingleResult();
+
+		//when
+		CommentSummaryResponse response = commentService.findComments(post.getId(), pageSize, FIRST_CURSOR_ID);
+		Slice<CommentInfoResponse> contents = response.getContents();
+
+		//then
+		assertNotEquals(-1L, response.getCursorId());
+		assertFalse(contents.hasNext());
+		assertNotEquals(pageSize, contents.getNumberOfElements());
+		Assertions.assertThat(contents).extracting(CommentInfoResponse::getProfileUrl).containsOnly("default");
+	}
+
+	@Test
+	void 댓글_조회_테스트_댓글이_없을때() {
+		int pageSize = 20;
+		Post post = em.createQuery("select p from Post p where p.user.nickname = :nickname", Post.class)
+			.setParameter("nickname", "noCommentUser")
+			.getSingleResult();
+
+		//when
+		CommentSummaryResponse response = commentService.findComments(post.getId(), pageSize, FIRST_CURSOR_ID);
+		Slice<CommentInfoResponse> contents = response.getContents();
+
+		//then
+		assertEquals(-1L, response.getCursorId());
+		assertFalse(contents.hasNext());
+		assertEquals(0, contents.getNumberOfElements());
+	}
+
+}

--- a/src/test/java/com/backend/naildp/service/CommentServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/CommentServiceTest.java
@@ -35,9 +35,9 @@ class CommentServiceTest {
 
 	@BeforeEach
 	void setup() {
-		User user = User.builder().nickname("user").phoneNumber("pn").agreement(true).role(UserRole.USER).build();
-		em.persist(user);
-		User commenter = User.builder().nickname("user").phoneNumber("pn").agreement(true).role(UserRole.USER).build();
+		User postWriter = User.builder().nickname("postWriter").phoneNumber("pn").agreement(true).role(UserRole.USER).build();
+		em.persist(postWriter);
+		User commenter = User.builder().nickname("commenter").phoneNumber("pn").agreement(true).role(UserRole.USER).build();
 		em.persist(commenter);
 		User noCommentUser = User.builder()
 			.nickname("noCommentUser")
@@ -47,7 +47,7 @@ class CommentServiceTest {
 			.build();
 		em.persist(noCommentUser);
 
-		Post post = Post.builder().user(user).postContent("content").tempSave(false).boundary(Boundary.ALL).build();
+		Post post = Post.builder().user(postWriter).postContent("content").tempSave(false).boundary(Boundary.ALL).build();
 		em.persist(post);
 		Post noCommentPost = Post.builder()
 			.user(noCommentUser)
@@ -68,7 +68,7 @@ class CommentServiceTest {
 		//given
 		int pageSize = COMMENT_CNT - 1;
 		Post post = em.createQuery("select p from Post p where p.user.nickname = :nickname", Post.class)
-			.setParameter("nickname", "user")
+			.setParameter("nickname", "postWriter")
 			.getSingleResult();
 
 		//when
@@ -87,7 +87,7 @@ class CommentServiceTest {
 		//given
 		int pageSize = COMMENT_CNT + 1;
 		Post post = em.createQuery("select p from Post p where p.user.nickname = :nickname", Post.class)
-			.setParameter("nickname", "user")
+			.setParameter("nickname", "postWriter")
 			.getSingleResult();
 
 		//when

--- a/src/test/java/com/backend/naildp/service/CommentServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/CommentServiceUnitTest.java
@@ -32,6 +32,7 @@ import com.backend.naildp.exception.ErrorCode;
 import com.backend.naildp.repository.CommentRepository;
 import com.backend.naildp.repository.FollowRepository;
 import com.backend.naildp.repository.PostRepository;
+import com.backend.naildp.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceUnitTest {
@@ -47,6 +48,9 @@ class CommentServiceUnitTest {
 
 	@Mock
 	FollowRepository followRepository;
+
+	@Mock
+	UserRepository userRepository;
 
 	@Test
 	void 임시저장_게시물에_댓글_등록_실패_테스트() {
@@ -102,23 +106,24 @@ class CommentServiceUnitTest {
 	@Test
 	void 댓글_등록_테스트() {
 		//given
-		User user = new User(new LoginRequestDto("nickname", "phoneNumber", true), UserRole.USER);
-		User writer = new User(new LoginRequestDto("writerNickname", "writerPhoneNumber", true), UserRole.USER);
-		Post post = createPost(writer, false, Boundary.FOLLOW);
-		Comment comment = new Comment(user, post, "댓글 등록 성공");
+		User commenter = new User(new LoginRequestDto("commenter", "phoneNumber", true), UserRole.USER);
+		User postWriter = new User(new LoginRequestDto("postWriter", "writerPhoneNumber", true), UserRole.USER);
+		Post post = createPost(postWriter, false, Boundary.FOLLOW);
+		Comment comment = new Comment(commenter, post, "댓글 등록 성공");
 
 		given(postRepository.findPostAndUser(anyLong())).willReturn(Optional.of(post));
-		given(followRepository.existsByFollowerNicknameAndFollowing(eq(user.getNickname()), eq(writer)))
+		given(followRepository.existsByFollowerNicknameAndFollowing(eq(commenter.getNickname()), eq(postWriter)))
 			.willReturn(true);
+		given(userRepository.findByNickname(eq(commenter.getNickname()))).willReturn(Optional.of(commenter));
 		given(commentRepository.save(any())).willReturn(comment);
 
 		//when
 		CommentRegisterDto commentRegisterDto = new CommentRegisterDto("댓글 등록 성공");
-		commentService.registerComment(1L, commentRegisterDto, user.getNickname());
+		commentService.registerComment(1L, commentRegisterDto, commenter.getNickname());
 
 		//then
 		verify(postRepository).findPostAndUser(post.getId());
-		verify(followRepository).existsByFollowerNicknameAndFollowing(user.getNickname(), writer);
+		verify(followRepository).existsByFollowerNicknameAndFollowing(commenter.getNickname(), postWriter);
 		verify(commentRepository).save(any(Comment.class));
 	}
 

--- a/src/test/java/com/backend/naildp/service/CommentServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/CommentServiceUnitTest.java
@@ -1,0 +1,128 @@
+package com.backend.naildp.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Import;
+
+import com.backend.naildp.common.Boundary;
+import com.backend.naildp.common.UserRole;
+import com.backend.naildp.config.JpaAuditingConfiguration;
+import com.backend.naildp.dto.auth.LoginRequestDto;
+import com.backend.naildp.dto.comment.CommentRegisterDto;
+import com.backend.naildp.entity.Comment;
+import com.backend.naildp.entity.Post;
+import com.backend.naildp.entity.User;
+import com.backend.naildp.exception.CustomException;
+import com.backend.naildp.repository.CommentRepository;
+import com.backend.naildp.repository.FollowRepository;
+import com.backend.naildp.repository.PostRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceUnitTest {
+
+	@InjectMocks
+	CommentService commentService;
+
+	@Mock
+	PostRepository postRepository;
+
+	@Mock
+	CommentRepository commentRepository;
+
+	@Mock
+	FollowRepository followRepository;
+
+	@Test
+	void 임시저장_게시물에_댓글_등록_실패_테스트() {
+		//given
+		User user = new User(new LoginRequestDto("nickname", "phoneNumber", true), UserRole.USER);
+		Post post = createPost(user, true, Boundary.ALL);
+
+		given(postRepository.findPostAndUser(anyLong())).willReturn(Optional.of(post));
+
+		//when
+		CommentRegisterDto commentRegisterDto = new CommentRegisterDto("임시저장인 게시물에 댓글 등록시 예외 발생");
+
+		//then
+		Assertions.assertThrows(CustomException.class,
+			() -> commentService.registerComment(1L, commentRegisterDto, "nickname"));
+	}
+
+	@Test
+	void 비공개_게시물_댓글_등록_실패_테스트() {
+		//given
+		User user = new User(new LoginRequestDto("nickname", "phoneNumber", true), UserRole.USER);
+		Post post = createPost(user, false, Boundary.NONE);
+
+		given(postRepository.findPostAndUser(anyLong())).willReturn(Optional.of(post));
+
+		//when
+		CommentRegisterDto commentRegisterDto = new CommentRegisterDto("비공개 게시물에 댓글 등록시 예외 발생");
+
+		//then
+		Assertions.assertThrows(CustomException.class,
+			() -> commentService.registerComment(1L, commentRegisterDto, "nickname"));
+	}
+
+	@Test
+	void 팔로우_게시물_댓글_등록_실패_테스트() {
+		//given
+		User user = new User(new LoginRequestDto("nickname", "phoneNumber", true), UserRole.USER);
+		User writer = new User(new LoginRequestDto("writerNickname", "writerPhoneNumber", true), UserRole.USER);
+		Post post = createPost(writer, false, Boundary.FOLLOW);
+
+		given(postRepository.findPostAndUser(anyLong())).willReturn(Optional.of(post));
+		given(followRepository.existsByFollowerNicknameAndFollowing(eq(user.getNickname()), eq(writer)))
+			.willReturn(false);
+
+		//when
+		CommentRegisterDto commentRegisterDto = new CommentRegisterDto("팔로우 공개 게시물에 댓글 등록시 예외 발생");
+
+		//then
+		Assertions.assertThrows(CustomException.class,
+			() -> commentService.registerComment(1L, commentRegisterDto, user.getNickname()));
+	}
+
+	@Test
+	void 댓글_등록_테스트() {
+		//given
+		User user = new User(new LoginRequestDto("nickname", "phoneNumber", true), UserRole.USER);
+		User writer = new User(new LoginRequestDto("writerNickname", "writerPhoneNumber", true), UserRole.USER);
+		Post post = createPost(writer, false, Boundary.FOLLOW);
+		Comment comment = new Comment(user, post, "댓글 등록 성공");
+
+		given(postRepository.findPostAndUser(anyLong())).willReturn(Optional.of(post));
+		given(followRepository.existsByFollowerNicknameAndFollowing(eq(user.getNickname()), eq(writer)))
+			.willReturn(true);
+		given(commentRepository.save(any())).willReturn(comment);
+
+		//when
+		CommentRegisterDto commentRegisterDto = new CommentRegisterDto("댓글 등록 성공");
+		commentService.registerComment(1L, commentRegisterDto, user.getNickname());
+
+		//then
+		verify(postRepository).findPostAndUser(post.getId());
+		verify(followRepository).existsByFollowerNicknameAndFollowing(user.getNickname(), writer);
+		verify(commentRepository).save(any(Comment.class));
+	}
+
+	private Post createPost(User user, boolean tempSave, Boundary boundary) {
+		return Post.builder()
+			.id(1L)
+			.user(user)
+			.postContent("content")
+			.tempSave(tempSave)
+			.boundary(boundary)
+			.build();
+	}
+
+}


### PR DESCRIPTION
### ✅ PR Type

- [x] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [x] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- 댓글 생성 API
- 댓글 수정 API
- 댓글 삭제 API
- 댓글 조회 API
- 특정 게시물 상세 조회 API 컨트롤러 수정

### 📝 상세 내용(Describe your changes)
- 댓글 생성 시 게시물 데이터에 따라 응답이 달라짐
    - 임시저장이거나 비공개라면 접근 불가
    - 팔로우 공개라면 게시물 작성자의 팔로워만 접근가능, 팔로워가 아니라면 접근 불가
- 댓글 수정, 삭제 기능은 요청한 사용자가 작성자와 동일한지 확인하는 로직이 들어가서 작성자만 조작 가능하도록 구현
- 댓글 조회 시 댓글 좋아요 개수와 생성날짜를 기반으로 내림차순으로 정렬하여 반환
    - 추후 대댓글 개수를 정렬 조건에 추가 예정
- 특정 게시물 상세 조회 API 가 요청이 안되는 현상
    - @AuthenticationPrincipal UserDetails userDetails 로 변경하여 로컬 테스트까지 확인 완료


### 🔗 Issue Number or Link

- #43 