### PR TITLE
[FEAT] 다른 유저 정보 조회

### DIFF
--- a/src/main/java/com/backend/naildp/common/ProfileInitializer.java
+++ b/src/main/java/com/backend/naildp/common/ProfileInitializer.java
@@ -1,0 +1,37 @@
+package com.backend.naildp.common;
+
+import org.springframework.context.annotation.Configuration;
+
+import com.backend.naildp.entity.Profile;
+import com.backend.naildp.repository.ProfileRepository;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class ProfileInitializer {
+	private final ProfileRepository profileRepository;
+
+	@PostConstruct
+	public void init() {
+
+		String baseUrl = "/assets/img/profile/basic/basic_";
+		String baseName = "Basic Profile ";
+		ProfileType profileType = ProfileType.BASIC;
+		boolean profileExist = profileRepository.existsProfileByProfileUrlStartsWith(baseUrl);
+		if (!profileExist) {
+			for (int i = 1; i <= 19; i++) {
+				String profileUrl = baseUrl + i + ".png";
+				String name = baseName + i;
+				Profile profile = Profile.builder()
+					.name(name)
+					.thumbnail(false)
+					.profileType(profileType)
+					.profileUrl(profileUrl)
+					.build();
+				profileRepository.save(profile);
+			}
+		}
+	}
+}

--- a/src/main/java/com/backend/naildp/controller/UserInfoController.java
+++ b/src/main/java/com/backend/naildp/controller/UserInfoController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,6 +37,17 @@ public class UserInfoController {
 		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo(userDetails.getUser().getNickname());
 
 		return ResponseEntity.ok(ApiResponse.successResponse(userInfoResponseDto, "사용자 정보 조회 성공", 2000));
+
+	}
+
+	@GetMapping("/{nickname}")
+	ResponseEntity<ApiResponse<?>> getOtherUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@PathVariable("nickname") String nickname) {
+
+		UserInfoResponseDto userInfoResponseDto = userInfoService.getOtherUserInfo(userDetails.getUser().getNickname(),
+			nickname);
+
+		return ResponseEntity.ok(ApiResponse.successResponse(userInfoResponseDto, "다른 사용자 정보 조회 성공", 2000));
 
 	}
 

--- a/src/main/java/com/backend/naildp/dto/userInfo/UserInfoResponseDto.java
+++ b/src/main/java/com/backend/naildp/dto/userInfo/UserInfoResponseDto.java
@@ -13,5 +13,6 @@ public class UserInfoResponseDto {
 	private String profileUrl;
 	private int followerCount;
 	private int followingCount;
+	private Boolean followingStatus;
 
 }

--- a/src/main/java/com/backend/naildp/repository/ProfileRepository.java
+++ b/src/main/java/com/backend/naildp/repository/ProfileRepository.java
@@ -16,4 +16,6 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 	List<String> findProfileUrlsByType(@Param("type") ProfileType profileType);
 
 	Optional<Profile> findProfileByProfileUrl(String profileUrl);
+
+	boolean existsProfileByProfileUrlStartsWith(String profileUrl);
 }

--- a/src/main/java/com/backend/naildp/service/UserInfoService.java
+++ b/src/main/java/com/backend/naildp/service/UserInfoService.java
@@ -70,9 +70,6 @@ public class UserInfoService {
 	@Transactional(readOnly = true)
 	public UserInfoResponseDto getOtherUserInfo(String myNickname, String otherNickname) {
 
-		User myUser = userRepository.findByNickname(myNickname)
-			.orElseThrow(() -> new CustomException("nickname 으로 회원을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
-
 		User otherUser = userRepository.findByNickname(otherNickname)
 			.orElseThrow(() -> new CustomException("nickname 으로 회원을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
 

--- a/src/main/java/com/backend/naildp/service/UserInfoService.java
+++ b/src/main/java/com/backend/naildp/service/UserInfoService.java
@@ -110,13 +110,13 @@ public class UserInfoService {
 
 		return UserInfoResponseDto.builder()
 			.nickname(otherUser.getNickname())
-			.point(otherUser.getPoint())
+			.point(null)
 			.profileUrl(otherUser.getThumbnailUrl())
 			.postsCount(postRepository.countPostsByUserAndTempSaveIsFalse(otherUser))
 			.saveCount(count)
 			.followerCount(followRepository.countFollowersByUserNickname(otherUser.getNickname()))
 			.followingCount(followRepository.countFollowingsByUserNickname(otherUser.getNickname()))
-			.followingStatus(followRepository.existsByFollowerNicknameAndFollowing(otherNickname, myUser))
+			.followingStatus(followRepository.existsByFollowerNicknameAndFollowing(myNickname, otherUser))
 			.build();
 	}
 

--- a/src/test/java/com/backend/naildp/service/UserInfoServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/UserInfoServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -102,6 +102,8 @@ class UserInfoServiceTest {
 		archive1 = new Archive(user1, "alswl archive", Boundary.ALL);
 
 		user1.updatePoint(1000L);
+
+		Follow follow = new Follow(user1, user2);
 	}
 
 	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 전체일 떄")
@@ -114,7 +116,7 @@ class UserInfoServiceTest {
 		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
 		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
 			List.of(archivePost1));
-		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(Collections.emptyList());
+		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(new ArrayList<>());
 		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
 			Optional.of(profile1.getProfileUrl()));
 		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
@@ -142,7 +144,7 @@ class UserInfoServiceTest {
 		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
 		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
 			List.of(archivePost1));
-		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(Collections.emptyList());
+		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(new ArrayList<>());
 		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
 			Optional.of(profile1.getProfileUrl()));
 		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
@@ -168,7 +170,7 @@ class UserInfoServiceTest {
 		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
 			List.of(archivePost1, archivePost2));
 		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(
-			List.of(user2.getNickname(), "user3"));
+			new ArrayList<>(List.of(user2.getNickname(), "user3")));
 		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
 			Optional.of(profile1.getProfileUrl()));
 		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
@@ -191,7 +193,8 @@ class UserInfoServiceTest {
 		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
 		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
 			List.of(archivePost1));
-		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(List.of(user2.getNickname()));
+		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(
+			new ArrayList<>(List.of(user2.getNickname())));
 		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
 			Optional.of(profile1.getProfileUrl()));
 		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);

--- a/src/test/java/com/backend/naildp/service/UserInfoServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/UserInfoServiceTest.java
@@ -2,428 +2,139 @@ package com.backend.naildp.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.backend.naildp.common.Boundary;
-import com.backend.naildp.common.ProfileType;
 import com.backend.naildp.common.UserRole;
-import com.backend.naildp.dto.post.FileRequestDto;
-import com.backend.naildp.dto.userInfo.ProfileRequestDto;
 import com.backend.naildp.dto.userInfo.UserInfoResponseDto;
 import com.backend.naildp.entity.Archive;
 import com.backend.naildp.entity.ArchivePost;
 import com.backend.naildp.entity.Follow;
 import com.backend.naildp.entity.Post;
-import com.backend.naildp.entity.Profile;
 import com.backend.naildp.entity.User;
-import com.backend.naildp.entity.UsersProfile;
 import com.backend.naildp.exception.CustomException;
+import com.backend.naildp.exception.ErrorCode;
 import com.backend.naildp.repository.ArchivePostRepository;
+import com.backend.naildp.repository.ArchiveRepository;
 import com.backend.naildp.repository.FollowRepository;
 import com.backend.naildp.repository.PostRepository;
-import com.backend.naildp.repository.ProfileRepository;
 import com.backend.naildp.repository.UserRepository;
-import com.backend.naildp.repository.UsersProfileRepository;
 
+@SpringBootTest
+@Transactional
 class UserInfoServiceTest {
-	@Mock
-	private UserRepository userRepository;
-	@Mock
-	private PostRepository postRepository;
-	@Mock
-	private ProfileRepository profileRepository;
-	@Mock
-	private ArchivePostRepository archivePostRepository;
-	@Mock
-	private FollowRepository followRepository;
-	@InjectMocks
+
+	@Autowired
 	private UserInfoService userInfoService;
-	@Mock
-	private UsersProfileRepository usersProfileRepository;
-	@Mock
-	S3Service s3Service;
 
-	private User user1;
-	private User user2;
-	private Profile profile1;
-	private Post post1;
-	private Post post2;
-	private Post post3;
-	private Archive archive1;
-	private ArchivePost archivePost1;
-	private ArchivePost archivePost2;
-	private Follow follow1;
+	@Autowired
+	private UserRepository userRepository;
 
-	private int followerCount;
+	@Autowired
+	private ArchivePostRepository archivePostRepository;
 
-	private UsersProfile usersProfile1;
-	private UsersProfile userProfile2;
+	@Autowired
+	private FollowRepository followRepository;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private ArchiveRepository archiveRepository;
+
+	private User myUser;
+	private User otherUser;
+	private Post post;
+	private ArchivePost archivePost;
 
 	@BeforeEach
 	void setUp() {
-		MockitoAnnotations.openMocks(this);
+		myUser = createUser("myUser");
+		otherUser = createUser("otherUser");
 
-		user1 = User.builder()
-			.nickname("alswl")
-			.agreement(true)
-			.phoneNumber("010-1234-5678")
-			.role(UserRole.USER)
-			.build();
-		user1.thumbnailUrlUpdate("alswl.profileUrl.jpg");
-		profile1 = Profile.builder()
-			.profileType(ProfileType.CUSTOMIZATION)
-			.name("name")
-			.profileUrl("alswl.profileUrl.jpg")
-			.thumbnail(true)
-			.build();
+		post = createPost(otherUser, Boundary.ALL);
+		Post myPost = createPost(myUser, Boundary.NONE);
 
-		usersProfile1 = UsersProfile.builder().user(user1).profile(profile1).build();
+		Archive otherArchive = archiveRepository.save(new Archive(otherUser, "otherArchive", Boundary.ALL));
 
-		post1 = new Post(user1, "alswl postContent", 0L, Boundary.ALL, false);
+		archivePostRepository.save(new ArchivePost(otherArchive, post));
+		archivePostRepository.save(new ArchivePost(otherArchive, myPost));
 
-		user2 = User.builder().nickname("jw").phoneNumber("010-9876-5432").agreement(true).role(UserRole.USER).build();
-		post2 = new Post(user2, "jw postContent", 0L, Boundary.ALL, false);
-		post3 = new Post(user2, "jw postContent", 0L, Boundary.ALL, true);
-
-		archive1 = new Archive(user1, "alswl archive", Boundary.ALL);
-
-		user1.updatePoint(1000L);
-
-		Follow follow = new Follow(user1, user2);
-	}
-
-	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 전체일 떄")
-	@Test
-	void testGetUserInfo_PostBoundaryAll() {
-		// Given
-		archivePost1 = new ArchivePost(archive1, post2);
-		followerCount = 0;
-
-		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
-		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
-			List.of(archivePost1));
-		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(new ArrayList<>());
-		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
-			Optional.of(profile1.getProfileUrl()));
-		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
-		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
-
-		// When
-		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo("alswl");
-
-		// Then
-		assertThat(userInfoResponseDto.getNickname()).isEqualTo("alswl");
-		assertThat(userInfoResponseDto.getPoint()).isEqualTo(1000L);
-		assertThat(userInfoResponseDto.getProfileUrl()).isEqualTo("alswl.profileUrl.jpg");
-		assertThat(userInfoResponseDto.getPostsCount()).isEqualTo(1);
-		assertThat(userInfoResponseDto.getSaveCount()).isEqualTo(1);
-		assertThat(userInfoResponseDto.getFollowerCount()).isEqualTo(followerCount);
-	}
-
-	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 팔로워일 때_notFollowing")
-	@Test
-	void testGetUserInfo_PostBoundaryFollow1() {
-		// Given
-		post2 = new Post(user2, "jw postContent", 0L, Boundary.FOLLOW, false);
-		archivePost1 = new ArchivePost(archive1, post2);
-
-		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
-		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
-			List.of(archivePost1));
-		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(new ArrayList<>());
-		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
-			Optional.of(profile1.getProfileUrl()));
-		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
-		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
-
-		// When
-		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo("alswl");
-
-		// Then
-		assertThat(userInfoResponseDto.getSaveCount()).isEqualTo(0);
-	}
-
-	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 팔로워일 때_Following")
-	@Test
-	void testGetUserInfo_PostBoundaryFollow2() {
-		// Given
-		post2 = new Post(user2, "jw postContent", 0L, Boundary.FOLLOW, false);
-		Post post4 = new Post(user2, "jw postContent", 0L, Boundary.FOLLOW, false);
-		archivePost1 = new ArchivePost(archive1, post2);
-		archivePost2 = new ArchivePost(archive1, post4);
-
-		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
-		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
-			List.of(archivePost1, archivePost2));
-		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(
-			new ArrayList<>(List.of(user2.getNickname(), "user3")));
-		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
-			Optional.of(profile1.getProfileUrl()));
-		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
-		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
-
-		// When
-		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo("alswl");
-
-		// Then
-		assertThat(userInfoResponseDto.getSaveCount()).isEqualTo(2);
-	}
-
-	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 비공개일 때")
-	@Test
-	void testGetUserInfo_PostBoundaryNone() {
-		// Given
-		post2 = new Post(user2, "jw postContent", 0L, Boundary.NONE, false);
-		archivePost1 = new ArchivePost(archive1, post2);
-		followerCount = 1;
-		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
-		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
-			List.of(archivePost1));
-		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(
-			new ArrayList<>(List.of(user2.getNickname())));
-		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
-			Optional.of(profile1.getProfileUrl()));
-		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
-		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
-
-		// When
-		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo("alswl");
-
-		// Then
-		assertThat(userInfoResponseDto.getSaveCount()).isEqualTo(0);
 	}
 
 	@Test
-	@DisplayName("사용자 정보 조회 - 사용자를 찾지 못할 때 예외 발생")
-	void testGetUserInfo_UserNotFound() {
-		// Given
-		given(userRepository.findByNickname("alswl")).willReturn(Optional.empty());
+	@DisplayName("다른 사용자 정보 가져오기 - 팔로우한 경우")
+	void getOtherUserInfo_Success() {
+		//given
+		followRepository.save(new Follow(myUser, otherUser));
 
-		// Then
-		assertThrows(CustomException.class, () -> userInfoService.getUserInfo("user1"));
+		//when
+		UserInfoResponseDto response = userInfoService.getOtherUserInfo(myUser.getNickname(), otherUser.getNickname());
+
+		//then
+		assertThat(response.getNickname()).isEqualTo(otherUser.getNickname());
+		assertThat(response.getPoint()).isEqualTo(null);
+		assertThat(response.getProfileUrl()).isEqualTo(otherUser.getThumbnailUrl());
+		assertThat(response.getPostsCount()).isEqualTo(1);
+		assertThat(response.getSaveCount()).isEqualTo(1);
+		assertThat(response.getFollowerCount()).isEqualTo(1);
+		assertThat(response.getFollowingCount()).isEqualTo(0);
+		assertThat(response.getFollowingStatus()).isTrue();
 	}
 
 	@Test
-	@DisplayName("포인트 조회")
-	void testGetPoint() {
-		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
+	@DisplayName("존재하지 않는 사용자 정보 조회")
+	void getOtherUserInfo_UserNotFound() {
+		//given
+		String notFoundUser = "notFoundUser";
 
-		Map<String, Object> result = userInfoService.getPoint("alswl");
-
-		assertThat(result.get("point")).isEqualTo(1000L);
-		verify(userRepository, times(1)).findByNickname(anyString());
-	}
-
-	@Test
-	@DisplayName("포인트 조회 - nickname없음")
-	void testGetPoint_UserNotFound() {
-		given(userRepository.findByNickname(anyString())).willReturn(Optional.empty());
-
-		CustomException exception = assertThrows(CustomException.class, () -> {
-			userInfoService.getPoint("testNickname");
-		});
+		//then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> userInfoService.getOtherUserInfo(myUser.getNickname(), notFoundUser));
 
 		assertThat(exception.getMessage()).isEqualTo("nickname 으로 회원을 찾을 수 없습니다.");
-		verify(userRepository, times(1)).findByNickname(anyString());
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
 	}
 
 	@Test
-	@DisplayName("프로필 업로드 성공 - 4개 이상")
-	void testUploadProfile1() {
-		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
-		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
-			Optional.of(usersProfile1));
-		given(usersProfileRepository.countByUserNicknameAndProfileProfileType(anyString(), any())).willReturn(4);
-		given(usersProfileRepository.findFirstByUserNicknameAndProfileProfileType(anyString(), any())).willReturn(
-			Optional.of(usersProfile1));
-		given(s3Service.saveFile(any(MultipartFile.class))).willReturn(new FileRequestDto("file1", 12345L, "fileUrl1"));
+	@DisplayName("다른 사용자 정보 가져오기 - 팔로우 아닌 경우")
+	void getOtherUserInfo_NoFollowers() {
+		followRepository.deleteAll();
+		// when
+		UserInfoResponseDto response = userInfoService.getOtherUserInfo(myUser.getNickname(), otherUser.getNickname());
 
-		userInfoService.uploadProfile("nickname", mock(MultipartFile.class));
-
-		verify(usersProfileRepository, times(1)).delete(any(UsersProfile.class));
-		verify(profileRepository, times(1)).delete(any(Profile.class));
-		verify(s3Service, times(1)).deleteFile(anyString());
-		verify(profileRepository, times(1)).save(any(Profile.class));
-		verify(usersProfileRepository, times(1)).save(any(UsersProfile.class));
+		// then
+		assertThat(response.getNickname()).isEqualTo(otherUser.getNickname());
+		assertThat(response.getPoint()).isEqualTo(null);
+		assertThat(response.getProfileUrl()).isEqualTo(otherUser.getThumbnailUrl());
+		assertThat(response.getPostsCount()).isEqualTo(1);
+		assertThat(response.getSaveCount()).isEqualTo(1);
+		assertThat(response.getFollowerCount()).isEqualTo(0);
+		assertThat(response.getFollowingCount()).isEqualTo(0);
+		assertThat(response.getFollowingStatus()).isFalse();
 	}
 
-	@Test
-	@DisplayName("프로필 업로드 성공 - 3개 이하")
-	void testUploadProfile2() {
-		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
-		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
-			Optional.of(usersProfile1));
-		given(usersProfileRepository.countByUserNicknameAndProfileProfileType(anyString(), any())).willReturn(3);
-		given(s3Service.saveFile(any(MultipartFile.class))).willReturn(new FileRequestDto("file1", 12345L, "fileUrl1"));
-
-		userInfoService.uploadProfile("testNickname", mock(MultipartFile.class));
-
-		verify(profileRepository, times(1)).save(any(Profile.class));
-		verify(usersProfileRepository, times(1)).save(any(UsersProfile.class));
+	private User createUser(String postWriter) {
+		User user = User.builder().nickname(postWriter).phoneNumber("pn").agreement(true).role(UserRole.USER).build();
+		userRepository.save(user);
+		return user;
 	}
 
-	@Test
-	@DisplayName("프로필 업로드 실패 - 현재 프로필")
-	void testUploadProfile_ProfileNotFound() {
-		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
-		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
-			Optional.empty());
-
-		CustomException exception = assertThrows(CustomException.class, () -> {
-			userInfoService.uploadProfile("testNickname", mock(MultipartFile.class));
-		});
-
-		assertThat(exception.getMessage()).isEqualTo("현재 프로필 이미지를 찾을 수 없습니다.");
-	}
-
-	@Test
-	@DisplayName("프로필 리스트 조회 성공 - CUSTOMIZATION")
-	void testGetProfiles_Customization() {
-		List<String> mockProfileUrls = Arrays.asList("test.jpg", "test.jpg");
-
-		given(usersProfileRepository.findProfileUrlsByNicknameAndCustomization(anyString())).willReturn(
-			mockProfileUrls);
-
-		Map<String, List<String>> result = userInfoService.getProfiles("testNickname", "CUSTOMIZATION");
-
-		assertThat(result.get("profileUrls")).isEqualTo(mockProfileUrls);
-
-		verify(usersProfileRepository, times(1)).findProfileUrlsByNicknameAndCustomization(anyString());
-		verify(profileRepository, times(0)).findProfileUrlsByType(any(ProfileType.class));
-	}
-
-	@Test
-	@DisplayName("프로필 리스트 조회 성공 - BASIC,ICON")
-	void testGetProfiles_OtherType() {
-		List<String> mockProfileUrls = Arrays.asList("test.jpg", "test.jpg");
-
-		given(profileRepository.findProfileUrlsByType(any(ProfileType.class))).willReturn(mockProfileUrls);
-
-		Map<String, List<String>> result = userInfoService.getProfiles("testNickname", "BASIC");
-
-		assertThat(result.get("profileUrls")).isEqualTo(mockProfileUrls);
-
-		verify(usersProfileRepository, times(0)).findProfileUrlsByNicknameAndCustomization(anyString());
-		verify(profileRepository, times(1)).findProfileUrlsByType(any(ProfileType.class));
-	}
-
-	@Test
-	@DisplayName("프로필 변경 성공 - CUSTOM -> CUSTOM")
-	void testChangeProfile1() {
-		ProfileRequestDto profileRequestDto = ProfileRequestDto.builder().profileUrl("changingProfileURl").build();
-
-		Profile currentProfile = Profile.builder()
-			.profileUrl("currentProfileURl")
-			.name("currentProfileURl")
-			.thumbnail(true)
-			.profileType(ProfileType.CUSTOMIZATION)
+	private Post createPost(User postWriter, Boundary boundary) {
+		Post post = Post.builder()
+			.user(postWriter)
+			.postContent(postWriter.getNickname() + "content")
+			.tempSave(false)
+			.boundary(boundary)
 			.build();
-
-		UsersProfile usersProfile = UsersProfile.builder().user(user1).profile(currentProfile).build();
-
-		Profile changingProfile = Profile.builder()
-			.thumbnail(false)
-			.profileUrl("changingProfileURl")
-			.name("changingProfileURl")
-			.profileType(ProfileType.CUSTOMIZATION)
-			.build();
-
-		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
-		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
-			Optional.of(usersProfile));
-		given(profileRepository.findProfileByProfileUrl(anyString())).willReturn(Optional.of(changingProfile));
-
-		userInfoService.changeProfile("testNickname", profileRequestDto);
-
-		verify(usersProfileRepository, times(0)).delete(usersProfile);
-		verify(usersProfileRepository, times(0)).save(any(UsersProfile.class));
-		assertThat(currentProfile.getThumbnail()).isFalse();
-		assertThat(changingProfile.getThumbnail()).isTrue();
+		postRepository.save(post);
+		return post;
 	}
 
-	@Test
-	@DisplayName("프로필 변경 성공 - BASIC -> CUSTOM")
-	void testChangeProfile2() {
-		ProfileRequestDto profileRequestDto = ProfileRequestDto.builder().profileUrl("changingProfileURl").build();
-
-		Profile currentProfile = Profile.builder()
-			.profileUrl("currentProfileURl")
-			.name("currentProfileURl")
-			.thumbnail(true)
-			.profileType(ProfileType.BASIC)
-			.build();
-
-		UsersProfile usersProfile = UsersProfile.builder().user(user1).profile(currentProfile).build();
-
-		Profile changingProfile = Profile.builder()
-			.thumbnail(false)
-			.profileUrl("changingProfileURl")
-			.name("changingProfileURl")
-			.profileType(ProfileType.CUSTOMIZATION)
-			.build();
-
-		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
-		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
-			Optional.of(usersProfile));
-		given(profileRepository.findProfileByProfileUrl(anyString())).willReturn(Optional.of(changingProfile));
-
-		userInfoService.changeProfile("testNickname", profileRequestDto);
-
-		verify(usersProfileRepository, times(1)).delete(usersProfile);
-		verify(usersProfileRepository, times(0)).save(any(UsersProfile.class));
-		assertThat(currentProfile.getThumbnail()).isFalse();
-		assertThat(changingProfile.getThumbnail()).isTrue();
-	}
-
-	@Test
-	@DisplayName("프로필 변경 성공 - CUSTOM -> BASIC")
-	void testChangeProfile3() {
-		ProfileRequestDto profileRequestDto = ProfileRequestDto.builder().profileUrl("changingProfileURl").build();
-
-		Profile currentProfile = Profile.builder()
-			.profileUrl("currentProfileURl")
-			.name("currentProfileURl")
-			.thumbnail(true)
-			.profileType(ProfileType.CUSTOMIZATION)
-			.build();
-
-		UsersProfile usersProfile = UsersProfile.builder().user(user1).profile(currentProfile).build();
-
-		Profile changingProfile = Profile.builder()
-			.thumbnail(false)
-			.profileUrl("changingProfileURl")
-			.name("changingProfileURl")
-			.profileType(ProfileType.BASIC)
-			.build();
-
-		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
-		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
-			Optional.of(usersProfile));
-		given(profileRepository.findProfileByProfileUrl(anyString())).willReturn(Optional.of(changingProfile));
-
-		userInfoService.changeProfile("testNickname", profileRequestDto);
-
-		verify(usersProfileRepository, times(0)).delete(usersProfile);
-		verify(usersProfileRepository, times(1)).save(any(UsersProfile.class));
-		assertThat(currentProfile.getThumbnail()).isFalse();
-		assertThat(changingProfile.getThumbnail()).isTrue();
-	}
 }
-
-
-
-

--- a/src/test/java/com/backend/naildp/service/UserInfoServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/UserInfoServiceUnitTest.java
@@ -1,0 +1,429 @@
+package com.backend.naildp.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.backend.naildp.common.Boundary;
+import com.backend.naildp.common.ProfileType;
+import com.backend.naildp.common.UserRole;
+import com.backend.naildp.dto.post.FileRequestDto;
+import com.backend.naildp.dto.userInfo.ProfileRequestDto;
+import com.backend.naildp.dto.userInfo.UserInfoResponseDto;
+import com.backend.naildp.entity.Archive;
+import com.backend.naildp.entity.ArchivePost;
+import com.backend.naildp.entity.Follow;
+import com.backend.naildp.entity.Post;
+import com.backend.naildp.entity.Profile;
+import com.backend.naildp.entity.User;
+import com.backend.naildp.entity.UsersProfile;
+import com.backend.naildp.exception.CustomException;
+import com.backend.naildp.repository.ArchivePostRepository;
+import com.backend.naildp.repository.FollowRepository;
+import com.backend.naildp.repository.PostRepository;
+import com.backend.naildp.repository.ProfileRepository;
+import com.backend.naildp.repository.UserRepository;
+import com.backend.naildp.repository.UsersProfileRepository;
+
+class UserInfoServiceUnitTest {
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private PostRepository postRepository;
+	@Mock
+	private ProfileRepository profileRepository;
+	@Mock
+	private ArchivePostRepository archivePostRepository;
+	@Mock
+	private FollowRepository followRepository;
+	@InjectMocks
+	private UserInfoService userInfoService;
+	@Mock
+	private UsersProfileRepository usersProfileRepository;
+	@Mock
+	S3Service s3Service;
+
+	private User user1;
+	private User user2;
+	private Profile profile1;
+	private Post post1;
+	private Post post2;
+	private Post post3;
+	private Archive archive1;
+	private ArchivePost archivePost1;
+	private ArchivePost archivePost2;
+	private Follow follow1;
+
+	private int followerCount;
+
+	private UsersProfile usersProfile1;
+	private UsersProfile userProfile2;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		user1 = User.builder()
+			.nickname("alswl")
+			.agreement(true)
+			.phoneNumber("010-1234-5678")
+			.role(UserRole.USER)
+			.build();
+		user1.thumbnailUrlUpdate("alswl.profileUrl.jpg");
+		profile1 = Profile.builder()
+			.profileType(ProfileType.CUSTOMIZATION)
+			.name("name")
+			.profileUrl("alswl.profileUrl.jpg")
+			.thumbnail(true)
+			.build();
+
+		usersProfile1 = UsersProfile.builder().user(user1).profile(profile1).build();
+
+		post1 = new Post(user1, "alswl postContent", 0L, Boundary.ALL, false);
+
+		user2 = User.builder().nickname("jw").phoneNumber("010-9876-5432").agreement(true).role(UserRole.USER).build();
+		post2 = new Post(user2, "jw postContent", 0L, Boundary.ALL, false);
+		post3 = new Post(user2, "jw postContent", 0L, Boundary.ALL, true);
+
+		archive1 = new Archive(user1, "alswl archive", Boundary.ALL);
+
+		user1.updatePoint(1000L);
+
+		Follow follow = new Follow(user1, user2);
+	}
+
+	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 전체일 떄")
+	@Test
+	void testGetUserInfo_PostBoundaryAll() {
+		// Given
+		archivePost1 = new ArchivePost(archive1, post2);
+		followerCount = 0;
+
+		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
+		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
+			List.of(archivePost1));
+		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(new ArrayList<>());
+		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.of(profile1.getProfileUrl()));
+		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
+		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
+
+		// When
+		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo("alswl");
+
+		// Then
+		assertThat(userInfoResponseDto.getNickname()).isEqualTo("alswl");
+		assertThat(userInfoResponseDto.getPoint()).isEqualTo(1000L);
+		assertThat(userInfoResponseDto.getProfileUrl()).isEqualTo("alswl.profileUrl.jpg");
+		assertThat(userInfoResponseDto.getPostsCount()).isEqualTo(1);
+		assertThat(userInfoResponseDto.getSaveCount()).isEqualTo(1);
+		assertThat(userInfoResponseDto.getFollowerCount()).isEqualTo(followerCount);
+	}
+
+	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 팔로워일 때_notFollowing")
+	@Test
+	void testGetUserInfo_PostBoundaryFollow1() {
+		// Given
+		post2 = new Post(user2, "jw postContent", 0L, Boundary.FOLLOW, false);
+		archivePost1 = new ArchivePost(archive1, post2);
+
+		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
+		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
+			List.of(archivePost1));
+		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(new ArrayList<>());
+		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.of(profile1.getProfileUrl()));
+		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
+		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
+
+		// When
+		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo("alswl");
+
+		// Then
+		assertThat(userInfoResponseDto.getSaveCount()).isEqualTo(0);
+	}
+
+	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 팔로워일 때_Following")
+	@Test
+	void testGetUserInfo_PostBoundaryFollow2() {
+		// Given
+		post2 = new Post(user2, "jw postContent", 0L, Boundary.FOLLOW, false);
+		Post post4 = new Post(user2, "jw postContent", 0L, Boundary.FOLLOW, false);
+		archivePost1 = new ArchivePost(archive1, post2);
+		archivePost2 = new ArchivePost(archive1, post4);
+
+		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
+		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
+			List.of(archivePost1, archivePost2));
+		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(
+			new ArrayList<>(List.of(user2.getNickname(), "user3")));
+		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.of(profile1.getProfileUrl()));
+		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
+		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
+
+		// When
+		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo("alswl");
+
+		// Then
+		assertThat(userInfoResponseDto.getSaveCount()).isEqualTo(2);
+	}
+
+	@DisplayName("사용자 정보 조회 - 저장한 포스트의 공개범위가 비공개일 때")
+	@Test
+	void testGetUserInfo_PostBoundaryNone() {
+		// Given
+		post2 = new Post(user2, "jw postContent", 0L, Boundary.NONE, false);
+		archivePost1 = new ArchivePost(archive1, post2);
+		followerCount = 1;
+		given(userRepository.findByNickname("alswl")).willReturn(Optional.of(user1));
+		given(archivePostRepository.findAllArchivePostsByUserNicknameAndTempSaveIsFalse("alswl")).willReturn(
+			List.of(archivePost1));
+		given(followRepository.findFollowingNicknamesByUserNickname("alswl")).willReturn(
+			new ArrayList<>(List.of(user2.getNickname())));
+		given(usersProfileRepository.findProfileUrlByNicknameAndThumbnailTrue(user1.getNickname())).willReturn(
+			Optional.of(profile1.getProfileUrl()));
+		given(postRepository.countPostsByUserAndTempSaveIsFalse(user1)).willReturn(1);
+		given(followRepository.countFollowersByUserNickname("alswl")).willReturn(followerCount);
+
+		// When
+		UserInfoResponseDto userInfoResponseDto = userInfoService.getUserInfo("alswl");
+
+		// Then
+		assertThat(userInfoResponseDto.getSaveCount()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("사용자 정보 조회 - 사용자를 찾지 못할 때 예외 발생")
+	void testGetUserInfo_UserNotFound() {
+		// Given
+		given(userRepository.findByNickname("alswl")).willReturn(Optional.empty());
+
+		// Then
+		assertThrows(CustomException.class, () -> userInfoService.getUserInfo("user1"));
+	}
+
+	@Test
+	@DisplayName("포인트 조회")
+	void testGetPoint() {
+		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
+
+		Map<String, Object> result = userInfoService.getPoint("alswl");
+
+		assertThat(result.get("point")).isEqualTo(1000L);
+		verify(userRepository, times(1)).findByNickname(anyString());
+	}
+
+	@Test
+	@DisplayName("포인트 조회 - nickname없음")
+	void testGetPoint_UserNotFound() {
+		given(userRepository.findByNickname(anyString())).willReturn(Optional.empty());
+
+		CustomException exception = assertThrows(CustomException.class, () -> {
+			userInfoService.getPoint("testNickname");
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("nickname 으로 회원을 찾을 수 없습니다.");
+		verify(userRepository, times(1)).findByNickname(anyString());
+	}
+
+	@Test
+	@DisplayName("프로필 업로드 성공 - 4개 이상")
+	void testUploadProfile1() {
+		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
+		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
+			Optional.of(usersProfile1));
+		given(usersProfileRepository.countByUserNicknameAndProfileProfileType(anyString(), any())).willReturn(4);
+		given(usersProfileRepository.findFirstByUserNicknameAndProfileProfileType(anyString(), any())).willReturn(
+			Optional.of(usersProfile1));
+		given(s3Service.saveFile(any(MultipartFile.class))).willReturn(new FileRequestDto("file1", 12345L, "fileUrl1"));
+
+		userInfoService.uploadProfile("nickname", mock(MultipartFile.class));
+
+		verify(usersProfileRepository, times(1)).delete(any(UsersProfile.class));
+		verify(profileRepository, times(1)).delete(any(Profile.class));
+		verify(s3Service, times(1)).deleteFile(anyString());
+		verify(profileRepository, times(1)).save(any(Profile.class));
+		verify(usersProfileRepository, times(1)).save(any(UsersProfile.class));
+	}
+
+	@Test
+	@DisplayName("프로필 업로드 성공 - 3개 이하")
+	void testUploadProfile2() {
+		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
+		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
+			Optional.of(usersProfile1));
+		given(usersProfileRepository.countByUserNicknameAndProfileProfileType(anyString(), any())).willReturn(3);
+		given(s3Service.saveFile(any(MultipartFile.class))).willReturn(new FileRequestDto("file1", 12345L, "fileUrl1"));
+
+		userInfoService.uploadProfile("testNickname", mock(MultipartFile.class));
+
+		verify(profileRepository, times(1)).save(any(Profile.class));
+		verify(usersProfileRepository, times(1)).save(any(UsersProfile.class));
+	}
+
+	@Test
+	@DisplayName("프로필 업로드 실패 - 현재 프로필")
+	void testUploadProfile_ProfileNotFound() {
+		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
+		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
+			Optional.empty());
+
+		CustomException exception = assertThrows(CustomException.class, () -> {
+			userInfoService.uploadProfile("testNickname", mock(MultipartFile.class));
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("현재 프로필 이미지를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("프로필 리스트 조회 성공 - CUSTOMIZATION")
+	void testGetProfiles_Customization() {
+		List<String> mockProfileUrls = Arrays.asList("test.jpg", "test.jpg");
+
+		given(usersProfileRepository.findProfileUrlsByNicknameAndCustomization(anyString())).willReturn(
+			mockProfileUrls);
+
+		Map<String, List<String>> result = userInfoService.getProfiles("testNickname", "CUSTOMIZATION");
+
+		assertThat(result.get("profileUrls")).isEqualTo(mockProfileUrls);
+
+		verify(usersProfileRepository, times(1)).findProfileUrlsByNicknameAndCustomization(anyString());
+		verify(profileRepository, times(0)).findProfileUrlsByType(any(ProfileType.class));
+	}
+
+	@Test
+	@DisplayName("프로필 리스트 조회 성공 - BASIC,ICON")
+	void testGetProfiles_OtherType() {
+		List<String> mockProfileUrls = Arrays.asList("test.jpg", "test.jpg");
+
+		given(profileRepository.findProfileUrlsByType(any(ProfileType.class))).willReturn(mockProfileUrls);
+
+		Map<String, List<String>> result = userInfoService.getProfiles("testNickname", "BASIC");
+
+		assertThat(result.get("profileUrls")).isEqualTo(mockProfileUrls);
+
+		verify(usersProfileRepository, times(0)).findProfileUrlsByNicknameAndCustomization(anyString());
+		verify(profileRepository, times(1)).findProfileUrlsByType(any(ProfileType.class));
+	}
+
+	@Test
+	@DisplayName("프로필 변경 성공 - CUSTOM -> CUSTOM")
+	void testChangeProfile1() {
+		ProfileRequestDto profileRequestDto = ProfileRequestDto.builder().profileUrl("changingProfileURl").build();
+
+		Profile currentProfile = Profile.builder()
+			.profileUrl("currentProfileURl")
+			.name("currentProfileURl")
+			.thumbnail(true)
+			.profileType(ProfileType.CUSTOMIZATION)
+			.build();
+
+		UsersProfile usersProfile = UsersProfile.builder().user(user1).profile(currentProfile).build();
+
+		Profile changingProfile = Profile.builder()
+			.thumbnail(false)
+			.profileUrl("changingProfileURl")
+			.name("changingProfileURl")
+			.profileType(ProfileType.CUSTOMIZATION)
+			.build();
+
+		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
+		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
+			Optional.of(usersProfile));
+		given(profileRepository.findProfileByProfileUrl(anyString())).willReturn(Optional.of(changingProfile));
+
+		userInfoService.changeProfile("testNickname", profileRequestDto);
+
+		verify(usersProfileRepository, times(0)).delete(usersProfile);
+		verify(usersProfileRepository, times(0)).save(any(UsersProfile.class));
+		assertThat(currentProfile.getThumbnail()).isFalse();
+		assertThat(changingProfile.getThumbnail()).isTrue();
+	}
+
+	@Test
+	@DisplayName("프로필 변경 성공 - BASIC -> CUSTOM")
+	void testChangeProfile2() {
+		ProfileRequestDto profileRequestDto = ProfileRequestDto.builder().profileUrl("changingProfileURl").build();
+
+		Profile currentProfile = Profile.builder()
+			.profileUrl("currentProfileURl")
+			.name("currentProfileURl")
+			.thumbnail(true)
+			.profileType(ProfileType.BASIC)
+			.build();
+
+		UsersProfile usersProfile = UsersProfile.builder().user(user1).profile(currentProfile).build();
+
+		Profile changingProfile = Profile.builder()
+			.thumbnail(false)
+			.profileUrl("changingProfileURl")
+			.name("changingProfileURl")
+			.profileType(ProfileType.CUSTOMIZATION)
+			.build();
+
+		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
+		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
+			Optional.of(usersProfile));
+		given(profileRepository.findProfileByProfileUrl(anyString())).willReturn(Optional.of(changingProfile));
+
+		userInfoService.changeProfile("testNickname", profileRequestDto);
+
+		verify(usersProfileRepository, times(1)).delete(usersProfile);
+		verify(usersProfileRepository, times(0)).save(any(UsersProfile.class));
+		assertThat(currentProfile.getThumbnail()).isFalse();
+		assertThat(changingProfile.getThumbnail()).isTrue();
+	}
+
+	@Test
+	@DisplayName("프로필 변경 성공 - CUSTOM -> BASIC")
+	void testChangeProfile3() {
+		ProfileRequestDto profileRequestDto = ProfileRequestDto.builder().profileUrl("changingProfileURl").build();
+
+		Profile currentProfile = Profile.builder()
+			.profileUrl("currentProfileURl")
+			.name("currentProfileURl")
+			.thumbnail(true)
+			.profileType(ProfileType.CUSTOMIZATION)
+			.build();
+
+		UsersProfile usersProfile = UsersProfile.builder().user(user1).profile(currentProfile).build();
+
+		Profile changingProfile = Profile.builder()
+			.thumbnail(false)
+			.profileUrl("changingProfileURl")
+			.name("changingProfileURl")
+			.profileType(ProfileType.BASIC)
+			.build();
+
+		given(userRepository.findByNickname(anyString())).willReturn(Optional.of(user1));
+		given(usersProfileRepository.findByUserNicknameAndProfileThumbnailTrue(anyString())).willReturn(
+			Optional.of(usersProfile));
+		given(profileRepository.findProfileByProfileUrl(anyString())).willReturn(Optional.of(changingProfile));
+
+		userInfoService.changeProfile("testNickname", profileRequestDto);
+
+		verify(usersProfileRepository, times(0)).delete(usersProfile);
+		verify(usersProfileRepository, times(1)).save(any(UsersProfile.class));
+		assertThat(currentProfile.getThumbnail()).isFalse();
+		assertThat(changingProfile.getThumbnail()).isTrue();
+	}
+}
+
+
+
+


### PR DESCRIPTION
### ✅ PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [x] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- 네디플에서 제공하는 기본 프로필 이미지 데이터 Initializer 
- 다른 사용자 정보 가져오기 getOtherUserInfo 구현
- 테스트 작성

### 📝 상세 내용(Describe your changes)
getOtherUserInfo, getUserInfo 메서드에서  saveCount 조건문 추가
- 변경 전
``` java
.filter(post -> {
	Boundary boundary = post.getBoundary();
	return boundary == Boundary.ALL || (boundary == Boundary.FOLLOW && followings.contains(
	post.getUser().getNickname()));
})
```
- 변경 후
``` java
.filter(post -> {
	Boundary boundary = post.getBoundary();
	return boundary == Boundary.ALL || (boundary == Boundary.FOLLOW && followings.contains(
	post.getUser().getNickname())) || (boundary == Boundary.NONE && !post.notWrittenBy(otherNickname));
})
```
본인이 올린 포스트는 boundary가 none이어도 count

### 🔗 Issue Number or Link
#67 