### PR TITLE
[FIX] : User 클래스 archiveCount 쿼리 소문자로 변경

### DIFF
--- a/src/main/java/com/backend/naildp/entity/User.java
+++ b/src/main/java/com/backend/naildp/entity/User.java
@@ -1,7 +1,5 @@
 package com.backend.naildp.entity;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.annotations.Formula;
@@ -16,7 +14,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -49,7 +46,7 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private String thumbnailUrl = "default";
 
-	@Formula("(select count(*) from Archive where Archive.user_id = user_id and Archive.boundary <> 'NONE' )")
+	@Formula("(select count(*) from archive where archive.user_id = user_id and archive.boundary <> 'NONE' )")
 	private int archiveCount;
 
 	@Builder


### PR DESCRIPTION

### ✅ PR Type

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

-  User 클래스 archiveCount 쿼리 소문자로 변경

### 📝 상세 내용(Describe your changes)

- 로컬디비와 달리 rds mysql에서는 대소문자를 구분하여 archivecount 쿼리에서 오류가 남

### 🔗 Issue Number or Link
