### PR TITLE
[FEAT] : 특정 게시물 읽기 API 저장유무 필드 추가

### DIFF
--- a/src/main/java/com/backend/naildp/dto/post/PostInfoResponse.java
+++ b/src/main/java/com/backend/naildp/dto/post/PostInfoResponse.java
@@ -31,12 +31,13 @@ public class PostInfoResponse {
 	private String boundary;
 	private long likeCount;
 	private boolean isLiked;
+	private boolean isSaved;
 	private long commentCount;
 	private long sharedCount;
 	private List<String> tags;
 
 	public static PostInfoResponse of(Post post, String userNickname, boolean followingStatus, int followerCount,
-		List<Tag> tags) {
+		List<Post> savedPost, List<Tag>tags) {
 
 		User writer = post.getUser();
 		List<PostLike> postLikes = post.getPostLikes();
@@ -51,6 +52,7 @@ public class PostInfoResponse {
 			.boundary(post.getBoundary().toString())
 			.likeCount(postLikes.size())
 			.isLiked(postLikes.stream().anyMatch(postLike -> postLike.isLikedBy(userNickname)))
+			.isSaved(savedPost.contains(post))
 			.commentCount(post.getComments().size())
 			.sharedCount(post.getSharing())
 			.tags(tags.stream().map(Tag::getName).collect(Collectors.toList()))

--- a/src/test/java/com/backend/naildp/entity/UserTest.java
+++ b/src/test/java/com/backend/naildp/entity/UserTest.java
@@ -9,7 +9,7 @@ import com.backend.naildp.common.UserRole;
 class UserTest {
 
 	@Test
-	void create() {
+	void userCreateTest() {
 
 		User user = User.builder()
 			.nickname("nick")
@@ -18,7 +18,6 @@ class UserTest {
 			.agreement(true)
 			.build();
 
-		assertThat(user.getThumbnailUrl()).isEqualTo("default");
 		assertThat(user.getPoint()).isEqualTo(0L);
 	}
 

--- a/src/test/java/com/backend/naildp/service/FollowServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/FollowServiceUnitTest.java
@@ -60,7 +60,7 @@ class FollowServiceUnitTest {
 			.thenReturn(Optional.of(follow));
 
 		//when
-		Long followId = followService.followUser(followerNickname, followingNickname);
+		Long followId = followService.followUser(followingNickname, followerNickname);
 
 		//then
 		verify(followRepository).findFollowByFollowerNicknameAndFollowingNickname(followerNickname, followingNickname);
@@ -85,7 +85,7 @@ class FollowServiceUnitTest {
 		when(followRepository.saveAndFlush(any(Follow.class))).thenReturn(follow);
 
 		//when
-		Long followId = followService.followUser(followerNickname, followingNickname);
+		Long followId = followService.followUser(followingNickname, followerNickname);
 
 		//then
 		verify(followRepository).findFollowByFollowerNicknameAndFollowingNickname(followerNickname, followingNickname);


### PR DESCRIPTION
### ✅ PR Type

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [x] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [x] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- 특정 게시물 읽기 API 저장 유무 필드 `isSaved` 필드 추가
- 팔로우 단위 테스트 수정

### 📝 상세 내용(Describe your changes)

- postId를 기반으로 post와 user를 가져온 후 사용자가 접근 가능한지 확인하는 로직 추가
- 저장된 게시물인지 확인하기 위해 isSaved 필드를 응답에 추가하고 저장한 게시물만 가져오는 로직 추가
- 팔로우 테스트에서 파라미터 순서가 달라서 예외가 발생하여 순서를 바꿈

### 🔗 Issue Number or Link
- #27 