### PR TITLE
[FIX] : 최신 게시물 조회 시 팔로우 공개 게시물 조회 안되는 문제 해결

### DIFF
--- a/src/main/java/com/backend/naildp/repository/PostRepository.java
+++ b/src/main/java/com/backend/naildp/repository/PostRepository.java
@@ -18,13 +18,14 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostSearchRep
 	Slice<Post> findPostsByBoundaryAndTempSaveFalse(Boundary boundary, PageRequest pageRequest);
 
 	@Query("select p from Post p where p.tempSave = false"
-		+ " and (p.boundary = 'ALL' or (p.boundary = 'FOLLOW' and p.user in :following))")
-	Slice<Post> findRecentPostsByFollowing(@Param("following") List<User> following, PageRequest pageRequest);
+		+ " and (p.boundary = 'ALL' or (p.boundary = 'FOLLOW' and (p.user in :following or p.user.nickname = :nickname)))")
+	Slice<Post> findRecentPostsByFollowing(@Param("following") List<User> following, @Param("nickname") String nickname,
+		PageRequest pageRequest);
 
 	@Query("select p from Post p where p.id < :id and p.tempSave = false"
-		+ " and (p.boundary = 'ALL' or (p.boundary = 'FOLLOW' and p.user in :following))")
+		+ " and (p.boundary = 'ALL' or (p.boundary = 'FOLLOW' and (p.user in :following or p.user.nickname = :nickname)))")
 	Slice<Post> findRecentPostsByIdAndFollowing(@Param("id") Long oldestPostId,
-		@Param("following") List<User> following, PageRequest pageRequest);
+		@Param("following") List<User> following, @Param("nickname") String nickname, PageRequest pageRequest);
 
 	Slice<Post> findPostsByIdBeforeAndBoundaryAndTempSaveFalse(Long id, Boundary boundary, PageRequest pageRequest);
 

--- a/src/main/java/com/backend/naildp/service/PostInfoService.java
+++ b/src/main/java/com/backend/naildp/service/PostInfoService.java
@@ -47,7 +47,7 @@ public class PostInfoService {
 		}
 
 		List<User> followingUser = followRepository.findFollowingUserByFollowerNickname(nickname);
-		Slice<Post> recentPosts = getRecentPosts(cursorPostId, followingUser, pageRequest);
+		Slice<Post> recentPosts = getRecentPosts(cursorPostId, followingUser, nickname, pageRequest);
 
 		if (recentPosts.isEmpty()) {
 			log.info("최신 게시물이 없습니다.");
@@ -104,11 +104,11 @@ public class PostInfoService {
 		return postRepository.findPostsByIdBeforeAndBoundaryAndTempSaveFalse(cursorPostId, Boundary.ALL, pageRequest);
 	}
 
-	private Slice<Post> getRecentPosts(long cursorPostId, List<User> followingUser, PageRequest pageRequest) {
+	private Slice<Post> getRecentPosts(long cursorPostId, List<User> followingUser, String username, PageRequest pageRequest) {
 		if (isFirstPage(cursorPostId)) {
-			return postRepository.findRecentPostsByFollowing(followingUser, pageRequest);
+			return postRepository.findRecentPostsByFollowing(followingUser, username, pageRequest);
 		}
-		return postRepository.findRecentPostsByIdAndFollowing(cursorPostId, followingUser, pageRequest);
+		return postRepository.findRecentPostsByIdAndFollowing(cursorPostId, followingUser, username, pageRequest);
 	}
 
 	private boolean isFirstPage(long cursorPostId) {

--- a/src/test/java/com/backend/naildp/repository/PostRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/PostRepositoryTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,104 +78,151 @@ class PostRepositoryTest {
 		log.info("========= 사전 데이터 끝 =========");
 	}
 
-	@DisplayName("전체공개이거나 팔로우 공개이고 임시저장이 아닌 게시물 페이징 조회 테스트")
+	@DisplayName("팔로워 사용자는 전체공개이거나 팔로워 공개 게시물을 조회할 수 있다.")
 	@Test
-	void offsetPagingPostsWithFollow() {
+	void readablePostByFollowerIsFollowAndAll() {
 		//given
-		int postCntOpened = TOTAL_POST_CNT * 3;
-		PageRequest pageRequest = PageRequest.of(0, postCntOpened, Sort.by(Sort.Direction.DESC, "id"));
-		List<Follow> follows = findFollowByFollowerNickname("jw");
-		List<User> followingsByJw = follows.stream().map(Follow::getFollowing).collect(Collectors.toList());
+		String followerUserNickname = "jw";
+		int readablePostCount = TOTAL_POST_CNT * 3;
+		PageRequest pageRequest = PageRequest.of(0, readablePostCount, Sort.by(Sort.Direction.DESC, "id"));
+		List<User> followings = findFollowByFollowerNickname(followerUserNickname).stream()
+			.map(Follow::getFollowing).toList();
 
 		//when
-		Slice<Post> recentPosts = postRepository.findRecentPostsByFollowing(followingsByJw, pageRequest);
+		Slice<Post> recentPosts = postRepository.findRecentPostsByFollowing(followings, followerUserNickname, pageRequest);
 
 		//then
-		assertThat(recentPosts.getSize()).isEqualTo(postCntOpened);
-		assertThat(recentPosts.getNumberOfElements()).isEqualTo(postCntOpened);
-		assertThat(recentPosts.getNumber()).isEqualTo(0);
-		assertThat(recentPosts.getSort().isSorted()).isTrue();
+		assertThat(recentPosts.getSize()).isEqualTo(readablePostCount);
+		assertThat(recentPosts.getNumberOfElements()).isEqualTo(readablePostCount);
 		assertThat(recentPosts).extracting("boundary").containsOnly(Boundary.FOLLOW, Boundary.ALL);
 		assertThat(recentPosts).extracting("tempSave").containsOnly(false);
 	}
 
-	@DisplayName("전체공개이거나 팔로우 공개이고 임시저장이 아닌 게시물 페이징 조회 테스트 - 두번째 호출부터")
+	@DisplayName("일반 사용자는 전체공개 게시물만 조회 가능")
 	@Test
-	void cursorPagingPostsWithFollow() {
+	void readablePostByNormalUserIsAll() {
 		//given
-		Post oldestPost = findOldestPost();
-		int postCntOpened = TOTAL_POST_CNT * 3;
-		long oldestPostId = oldestPost.getId() + 1;
-		System.out.println("oldestPostId = " + oldestPostId);
-
-		PageRequest pageRequest = PageRequest.of(0, postCntOpened, Sort.by(Sort.Direction.DESC, "id"));
-		List<Follow> follows = findFollowByFollowerNickname("jw");
-		List<User> followingsByJw = follows.stream().map(Follow::getFollowing).collect(Collectors.toList());
+		String normalUserNickname = "normal";
+		int readablePostCount = TOTAL_POST_CNT * 2;
+		PageRequest pageRequest = PageRequest.of(0, readablePostCount, Sort.by(Sort.Direction.DESC, "id"));
+		List<User> followings = findFollowByFollowerNickname(normalUserNickname).stream()
+			.map(Follow::getFollowing)
+			.toList();
 
 		//when
-		Slice<Post> secondRecentPosts = postRepository.findRecentPostsByIdAndFollowing(oldestPostId, followingsByJw,
-			pageRequest);
+		Slice<Post> recentPosts = postRepository.findRecentPostsByFollowing(followings, normalUserNickname, pageRequest);
 
 		//then
-		assertThat(secondRecentPosts.getSize()).isEqualTo(postCntOpened);
-		assertThat(secondRecentPosts.getNumberOfElements()).isEqualTo(postCntOpened);
-		assertThat(secondRecentPosts.getNumber()).isEqualTo(0);
-		assertThat(secondRecentPosts.getSort().isSorted()).isTrue();
+		assertThat(recentPosts.getSize()).isEqualTo(readablePostCount);
+		assertThat(recentPosts.getNumberOfElements()).isEqualTo(readablePostCount);
+		assertThat(recentPosts).extracting("boundary").containsOnly(Boundary.ALL);
+		assertThat(recentPosts).extracting("tempSave").containsOnly(false);
+	}
+
+	@DisplayName("게시물 작성자는 전체공개 게시물과 팔로잉하는 사용자의 팔로우 공개 게시물을 조회 가능")
+	@Test
+	void readablePostByWriterIsFollowAndAll() {
+		//given
+		String writerNickname = "mj";
+		int readablePostCnt = TOTAL_POST_CNT * 3;
+		PageRequest pageRequest = PageRequest.of(0, readablePostCnt, Sort.by(Sort.Direction.DESC, "id"));
+		List<User> followings = findFollowByFollowerNickname(writerNickname).stream()
+			.map(Follow::getFollowing).toList();
+
+		//when
+		Slice<Post> recentPosts = postRepository.findRecentPostsByFollowing(followings, writerNickname, pageRequest);
+
+		//then
+		assertThat(recentPosts.getSize()).isEqualTo(readablePostCnt);
+		assertThat(recentPosts.getNumberOfElements()).isEqualTo(readablePostCnt);
+		assertThat(recentPosts).extracting("boundary").containsOnly(Boundary.FOLLOW, Boundary.ALL);
+		assertThat(recentPosts).extracting("tempSave").containsOnly(false);
+	}
+
+	@DisplayName("팔로워 사용자는 전체공개이거나 팔로잉 사용자의 팔로워 공개 게시물을 조회할 수 있다. - 커서 페이징")
+	@Test
+	void readablePostByFollowerIsFollowAndAllWithUsingCursor() {
+		//given
+		String followerUserNickname = "jw";
+		int firstPageElementCount = 1;
+		int readablePostCount = TOTAL_POST_CNT * 3 - firstPageElementCount;
+		PageRequest firstPageRequest = PageRequest.of(0, firstPageElementCount, Sort.by(Sort.Direction.DESC, "id"));
+		PageRequest pageRequest = PageRequest.of(0, readablePostCount, Sort.by(Sort.Direction.DESC, "id"));
+		List<User> followings = findFollowByFollowerNickname(followerUserNickname).stream()
+			.map(Follow::getFollowing).toList();
+
+		//when
+		Long cursorPostId = postRepository.findRecentPostsByFollowing(followings, followerUserNickname, firstPageRequest)
+			.getContent().get(firstPageElementCount - 1).getId();
+		Slice<Post> secondRecentPosts = postRepository.findRecentPostsByIdAndFollowing(cursorPostId, followings,
+			followerUserNickname, pageRequest);
+
+		//then
+		assertThat(secondRecentPosts.getSize()).isEqualTo(readablePostCount);
+		assertThat(secondRecentPosts.getNumberOfElements()).isEqualTo(readablePostCount);
 		assertThat(secondRecentPosts).extracting("boundary").containsOnly(Boundary.FOLLOW, Boundary.ALL);
 		assertThat(secondRecentPosts).extracting("tempSave").containsOnly(false);
 	}
 
-	@DisplayName("postId로 Post와 User 페치조인 테스트")
+	@DisplayName("일반 사용자는 전체공개 게시물을 조회할 수 있다. - 커서 페이징")
 	@Test
-	void findPostsAndWriter() {
+	void readablePostByNormalUserIsAllWithUsingCursor() {
 		//given
-		String nickname = "mj";
-		User user = em.createQuery("select u from Users u where u.nickname = :nickname", User.class)
-			.setParameter("nickname", nickname)
-			.getSingleResult();
-		List<Post> posts = em.createQuery(
-				"select p from Post p join fetch p.user u where u = :user and p.tempSave = false",
-				Post.class)
-			.setParameter("user", user)
-			.getResultList();
+		String normalUserNickname = "normalUserNickname";
+		int firstPageElementCount = 1;
+		int readablePostCount = TOTAL_POST_CNT * 2 - firstPageElementCount;
+		PageRequest firstPageRequest = PageRequest.of(0, firstPageElementCount, Sort.by(Sort.Direction.DESC, "id"));
+		PageRequest pageRequest = PageRequest.of(0, readablePostCount, Sort.by(Sort.Direction.DESC, "id"));
+		List<User> followings = findFollowByFollowerNickname(normalUserNickname).stream()
+			.map(Follow::getFollowing).toList();
 
 		//when
-		List<Post> findPosts = posts.stream()
-			.map(post -> postRepository.findPostAndWriterById(post.getId()).orElseThrow())
-			.collect(Collectors.toList());
+		Long cursorPostId = postRepository.findRecentPostsByFollowing(followings, normalUserNickname, firstPageRequest)
+			.getContent().get(firstPageElementCount - 1).getId();
+		Slice<Post> secondRecentPosts = postRepository.findRecentPostsByIdAndFollowing(cursorPostId, followings,
+			normalUserNickname, pageRequest);
 
 		//then
-		assertThat(findPosts).extracting("tempSave").containsOnly(false);
-		assertThat(findPosts).extracting("user").containsOnly(user);
+		assertThat(secondRecentPosts.getSize()).isEqualTo(readablePostCount);
+		assertThat(secondRecentPosts.getNumberOfElements()).isEqualTo(readablePostCount);
+		assertThat(secondRecentPosts).extracting("boundary").containsOnly(Boundary.ALL);
+		assertThat(secondRecentPosts).extracting("tempSave").containsOnly(false);
+	}
+
+	@DisplayName("게시물 작성자는 전체공개 게시물과 팔로잉하는 사용자의 팔로우 공개 게시물을 조회할 수 있다. - 커서 페이징")
+	@Test
+	void readablePostByWriterIsFollowAndAllWithUsingCursor() {
+		//given
+		String writerNickname = "mj";
+		int firstPageElementCount = 1;
+		int readablePostCount = TOTAL_POST_CNT * 2 - firstPageElementCount;
+		PageRequest firstPageRequest = PageRequest.of(0, firstPageElementCount, Sort.by(Sort.Direction.DESC, "id"));
+		PageRequest pageRequest = PageRequest.of(0, readablePostCount, Sort.by(Sort.Direction.DESC, "id"));
+		List<User> followings = findFollowByFollowerNickname(writerNickname).stream()
+			.map(Follow::getFollowing).toList();
+
+		//when
+		Long cursorPostId = postRepository.findRecentPostsByFollowing(followings, writerNickname, firstPageRequest)
+			.getContent().get(firstPageElementCount - 1).getId();
+		Slice<Post> secondRecentPosts = postRepository.findRecentPostsByIdAndFollowing(cursorPostId, followings,
+			writerNickname, pageRequest);
+
+		//then
+		assertThat(secondRecentPosts.getSize()).isEqualTo(readablePostCount);
+		assertThat(secondRecentPosts.getNumberOfElements()).isEqualTo(readablePostCount);
+		assertThat(secondRecentPosts).extracting("boundary").containsOnly(Boundary.FOLLOW, Boundary.ALL);
+		assertThat(secondRecentPosts).extracting("tempSave").containsOnly(false);
 	}
 
 	private void createTestTempSavePostAndPhoto(User user) {
 		Post post = new Post(user, "임시저장 게시물 - " + user.getNickname(), 0L, Boundary.ALL, true);
-		FileRequestDto fileRequestDto1 = new FileRequestDto("임시저장 photo 1-", 1L, "임시저장 url 1");
-		FileRequestDto fileRequestDto2 = new FileRequestDto("임시저장 photo 2-", 1L, "임시저장 url 2");
-		Photo photo1 = new Photo(post, fileRequestDto1);
-		Photo photo2 = new Photo(post, fileRequestDto2);
-		post.addPhoto(photo1);
-		post.addPhoto(photo2);
 		posts.add(post);
-		photos.add(photo1);
-		photos.add(photo2);
 	}
 
 	private void createTestPostWithPhoto(int postCnt, User user, Boundary boundary) {
 		for (int i = 0; i < postCnt; i++) {
 			Post post = new Post(user, "" + i, 0L, boundary, false);
-			FileRequestDto fileRequestDto1 = new FileRequestDto("photo 1-" + user.getNickname() + i, 1L,
-				"url 1-" + user.getNickname() + i);
-			FileRequestDto fileRequestDto2 = new FileRequestDto("photo 2-" + user.getNickname() + i, 1L,
-				"url 2-" + user.getNickname() + i);
-			Photo photo1 = new Photo(post, fileRequestDto1);
-			Photo photo2 = new Photo(post, fileRequestDto2);
-			post.addPhoto(photo1);
-			post.addPhoto(photo2);
 			posts.add(post);
-			photos.add(photo1);
-			photos.add(photo2);
 		}
 	}
 

--- a/src/test/java/com/backend/naildp/service/PostInfoServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/PostInfoServiceUnitTest.java
@@ -75,8 +75,8 @@ class PostInfoServiceUnitTest {
 		List<PostLike> postLikes = likePosts(recentPosts);
 
 		when(followRepository.findFollowingUserByFollowerNickname(anyString())).thenReturn(followingUser);
-		// when(postRepository.findRecentPostsByFollowing(anyList(), eq(pageRequest)))
-		// 	.thenReturn(recentPosts);
+		when(postRepository.findRecentPostsByFollowing(anyList(), anyString(), eq(pageRequest)))
+			.thenReturn(recentPosts);
 		when(archivePostRepository.findAllByArchiveUserNickname(eq(NICKNAME))).thenReturn(archivePosts);
 		when(postLikeRepository.findAllByUserNickname(eq(NICKNAME))).thenReturn(postLikes);
 
@@ -87,11 +87,13 @@ class PostInfoServiceUnitTest {
 
 		//then
 		verify(followRepository).findFollowingUserByFollowerNickname(anyString());
-		// verify(postRepository).findRecentPostsByFollowing(anyList(), eq(pageRequest));
-		// verify(postRepository, never()).findRecentPostsByIdAndFollowing(anyLong(),
-		// 	anyList(), any(PageRequest.class));
+		verify(postRepository).findRecentPostsByFollowing(anyList(), anyString(), eq(pageRequest));
+
 		verify(archivePostRepository).findAllByArchiveUserNickname(NICKNAME);
 		verify(postLikeRepository).findAllByUserNickname(NICKNAME);
+
+		verify(postRepository, never()).findRecentPostsByIdAndFollowing(anyLong(), anyList(), anyString(),
+			any(PageRequest.class));
 
 		assertThat(homePostResponses.getNumber()).isEqualTo(0);
 		assertThat(homePostResponses.getSize()).isEqualTo(20);
@@ -113,8 +115,8 @@ class PostInfoServiceUnitTest {
 		List<PostLike> postLikes = likePosts(pagedPost);
 
 		when(followRepository.findFollowingUserByFollowerNickname(anyString())).thenReturn(followingUser);
-		// when(postRepository.findRecentPostsByIdAndFollowing(eq(cursorPostId), anyList(), eq(pageRequest)))
-		// 	.thenReturn(pagedPost);
+		when(postRepository.findRecentPostsByIdAndFollowing(eq(cursorPostId), anyList(), anyString(), eq(pageRequest)))
+			.thenReturn(pagedPost);
 		when(archivePostRepository.findAllByArchiveUserNickname(NICKNAME)).thenReturn(archivePosts);
 		when(postLikeRepository.findAllByUserNickname(NICKNAME)).thenReturn(postLikes);
 
@@ -124,10 +126,11 @@ class PostInfoServiceUnitTest {
 
 		//then
 		verify(followRepository).findFollowingUserByFollowerNickname(anyString());
-		// verify(postRepository).findRecentPostsByIdAndFollowing(eq(cursorPostId), anyList(), eq(pageRequest));
-		// verify(postRepository, never()).findRecentPostsByFollowing(anyList(), eq(pageRequest));
+		verify(postRepository).findRecentPostsByIdAndFollowing(eq(cursorPostId), anyList(), anyString(), eq(pageRequest));
 		verify(archivePostRepository).findAllByArchiveUserNickname(NICKNAME);
 		verify(postLikeRepository).findAllByUserNickname(NICKNAME);
+
+		verify(postRepository, never()).findRecentPostsByFollowing(anyList(), anyString(), eq(pageRequest));
 
 		assertThat(homePostResponses.getNumber()).isEqualTo(0);
 		assertThat(homePostResponses.getSize()).isEqualTo(20);
@@ -147,8 +150,8 @@ class PostInfoServiceUnitTest {
 		Slice<Post> recentPosts = new SliceImpl<>(posts, pageRequest, false);
 
 		when(followRepository.findFollowingUserByFollowerNickname(anyString())).thenReturn(followingUser);
-		// when(postRepository.findRecentPostsByFollowing(anyList(), eq(pageRequest)))
-		// 	.thenReturn(recentPosts);
+		when(postRepository.findRecentPostsByFollowing(anyList(), anyString(), eq(pageRequest)))
+			.thenReturn(recentPosts);
 
 		//when
 		PostSummaryResponse response = postInfoService.homePosts("NEW", PAGE_SIZE, cursorPostId, NICKNAME);
@@ -161,7 +164,7 @@ class PostInfoServiceUnitTest {
 		assertThat(postSummaryList.getNumberOfElements()).isEqualTo(0);
 
 		verify(followRepository).findFollowingUserByFollowerNickname(anyString());
-		// verify(postRepository).findRecentPostsByFollowing(anyList(), eq(pageRequest));
+		verify(postRepository).findRecentPostsByFollowing(anyList(), anyString(), eq(pageRequest));
 		verify(archivePostRepository, never()).findAllByArchiveUserNickname(NICKNAME);
 		verify(postLikeRepository, never()).findAllByUserNickname(NICKNAME);
 	}
@@ -243,11 +246,6 @@ class PostInfoServiceUnitTest {
 
 		//then
 		verify(postRepository).findPostsByBoundaryAndTempSaveFalse(Boundary.ALL, pageRequest);
-		// verify(postRepository, never())
-		// 	.findPostsByBoundaryNotAndTempSaveFalse(any(Boundary.class), any(PageRequest.class));
-		// verify(postRepository, never())
-		// 	.findPostsByIdBeforeAndBoundaryNotAndTempSaveIsFalse(anyLong(), any(Boundary.class),
-		// 		any(PageRequest.class));
 		verify(archivePostRepository, never()).findAllByArchiveUserNickname(NICKNAME);
 		verify(postLikeRepository, never()).findAllByUserNickname(NICKNAME);
 	}

--- a/src/test/java/com/backend/naildp/service/PostInfoServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/PostInfoServiceUnitTest.java
@@ -75,8 +75,8 @@ class PostInfoServiceUnitTest {
 		List<PostLike> postLikes = likePosts(recentPosts);
 
 		when(followRepository.findFollowingUserByFollowerNickname(anyString())).thenReturn(followingUser);
-		when(postRepository.findRecentPostsByFollowing(anyList(), eq(pageRequest)))
-			.thenReturn(recentPosts);
+		// when(postRepository.findRecentPostsByFollowing(anyList(), eq(pageRequest)))
+		// 	.thenReturn(recentPosts);
 		when(archivePostRepository.findAllByArchiveUserNickname(eq(NICKNAME))).thenReturn(archivePosts);
 		when(postLikeRepository.findAllByUserNickname(eq(NICKNAME))).thenReturn(postLikes);
 
@@ -87,9 +87,9 @@ class PostInfoServiceUnitTest {
 
 		//then
 		verify(followRepository).findFollowingUserByFollowerNickname(anyString());
-		verify(postRepository).findRecentPostsByFollowing(anyList(), eq(pageRequest));
-		verify(postRepository, never()).findRecentPostsByIdAndFollowing(anyLong(),
-			anyList(), any(PageRequest.class));
+		// verify(postRepository).findRecentPostsByFollowing(anyList(), eq(pageRequest));
+		// verify(postRepository, never()).findRecentPostsByIdAndFollowing(anyLong(),
+		// 	anyList(), any(PageRequest.class));
 		verify(archivePostRepository).findAllByArchiveUserNickname(NICKNAME);
 		verify(postLikeRepository).findAllByUserNickname(NICKNAME);
 
@@ -113,8 +113,8 @@ class PostInfoServiceUnitTest {
 		List<PostLike> postLikes = likePosts(pagedPost);
 
 		when(followRepository.findFollowingUserByFollowerNickname(anyString())).thenReturn(followingUser);
-		when(postRepository.findRecentPostsByIdAndFollowing(eq(cursorPostId), anyList(), eq(pageRequest)))
-			.thenReturn(pagedPost);
+		// when(postRepository.findRecentPostsByIdAndFollowing(eq(cursorPostId), anyList(), eq(pageRequest)))
+		// 	.thenReturn(pagedPost);
 		when(archivePostRepository.findAllByArchiveUserNickname(NICKNAME)).thenReturn(archivePosts);
 		when(postLikeRepository.findAllByUserNickname(NICKNAME)).thenReturn(postLikes);
 
@@ -124,8 +124,8 @@ class PostInfoServiceUnitTest {
 
 		//then
 		verify(followRepository).findFollowingUserByFollowerNickname(anyString());
-		verify(postRepository).findRecentPostsByIdAndFollowing(eq(cursorPostId), anyList(), eq(pageRequest));
-		verify(postRepository, never()).findRecentPostsByFollowing(anyList(), eq(pageRequest));
+		// verify(postRepository).findRecentPostsByIdAndFollowing(eq(cursorPostId), anyList(), eq(pageRequest));
+		// verify(postRepository, never()).findRecentPostsByFollowing(anyList(), eq(pageRequest));
 		verify(archivePostRepository).findAllByArchiveUserNickname(NICKNAME);
 		verify(postLikeRepository).findAllByUserNickname(NICKNAME);
 
@@ -147,8 +147,8 @@ class PostInfoServiceUnitTest {
 		Slice<Post> recentPosts = new SliceImpl<>(posts, pageRequest, false);
 
 		when(followRepository.findFollowingUserByFollowerNickname(anyString())).thenReturn(followingUser);
-		when(postRepository.findRecentPostsByFollowing(anyList(), eq(pageRequest)))
-			.thenReturn(recentPosts);
+		// when(postRepository.findRecentPostsByFollowing(anyList(), eq(pageRequest)))
+		// 	.thenReturn(recentPosts);
 
 		//when
 		PostSummaryResponse response = postInfoService.homePosts("NEW", PAGE_SIZE, cursorPostId, NICKNAME);
@@ -161,7 +161,7 @@ class PostInfoServiceUnitTest {
 		assertThat(postSummaryList.getNumberOfElements()).isEqualTo(0);
 
 		verify(followRepository).findFollowingUserByFollowerNickname(anyString());
-		verify(postRepository).findRecentPostsByFollowing(anyList(), eq(pageRequest));
+		// verify(postRepository).findRecentPostsByFollowing(anyList(), eq(pageRequest));
 		verify(archivePostRepository, never()).findAllByArchiveUserNickname(NICKNAME);
 		verify(postLikeRepository, never()).findAllByUserNickname(NICKNAME);
 	}


### PR DESCRIPTION
### ✅ PR Type

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- 최신 게시물 조회 시 게시물 작성자가 팔로우 공개 게시물을 못보는 문제

### 📝 상세 내용(Describe your changes)
- `postRepository`-`findRecentPostByFollowing`, `findRecentPostByIdAndFollowing` -> 팔로우공개 게시물인 경우 작성자인지 확인하는 조건 추가
- 추후 querydsl로 변경 예정

### 🔗 Issue Number or Link
- #27 