### PR TITLE
[FEAT] : 사용자 검색 API, 연관 태그 검색 API 수정

### DIFF
--- a/src/main/java/com/backend/naildp/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/backend/naildp/repository/UserRepositoryImpl.java
@@ -8,10 +8,16 @@ import static com.backend.naildp.entity.QUser.*;
 import java.util.List;
 
 import com.backend.naildp.dto.search.SearchUserResponse;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.BooleanPath;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -29,6 +35,9 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 	public List<SearchUserResponse> searchByKeyword(String keyword, String nickname) {
 		// 사용자 닉네임, 프로필
 		// 게시물 수, 저장된 게시물 수, 팔로워 수
+
+		NumberExpression<Integer> userSorting = userSortingOrder(keyword);
+
 		BooleanPath isFollowing = Expressions.booleanPath("isFollowing");
 
 		return queryFactory
@@ -58,11 +67,20 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 						.where(follow.following.eq(user), follow.follower.nickname.eq(nickname)), isFollowing)
 			))
 			.from(user)
-			.where(user.nickname.like(keyword + "%"))
-			.orderBy(isFollowing.desc(), user.nickname.asc())
+			.where(containInNickname(keyword))
+			.orderBy(isFollowing.desc(), userSorting.desc(), user.nickname.asc())
 			.limit(10)
 			.fetch();
-		// return null;
+	}
+
+	private NumberExpression<Integer> userSortingOrder(String keyword) {
+		return new CaseBuilder()
+			.when(user.nickname.startsWith(keyword)).then(2)
+			.otherwise(1);
+	}
+
+	private BooleanExpression containInNickname(String keyword) {
+		return user.nickname.contains(keyword);
 	}
 
 }

--- a/src/test/java/com/backend/naildp/repository/UserSearchRepositoryTest.java
+++ b/src/test/java/com/backend/naildp/repository/UserSearchRepositoryTest.java
@@ -1,5 +1,9 @@
 package com.backend.naildp.repository;
 
+import static com.backend.naildp.entity.QArchivePost.*;
+import static com.backend.naildp.entity.QFollow.*;
+import static com.backend.naildp.entity.QPost.*;
+import static com.backend.naildp.entity.QUser.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
@@ -20,6 +24,15 @@ import com.backend.naildp.dto.search.SearchUserResponse;
 import com.backend.naildp.entity.Follow;
 import com.backend.naildp.entity.Post;
 import com.backend.naildp.entity.User;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.BooleanPath;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import jakarta.persistence.EntityManager;
@@ -42,7 +55,7 @@ public class UserSearchRepositoryTest {
 	UserRepository userRepository;
 
 	final String NICKNAME_PREFIX = "x";
-	final int SEARCH_USER_CNT = 50;
+	final int SEARCH_USER_CNT = 20;
 	final int POST_CNT = 10;
 
 	@BeforeEach
@@ -55,9 +68,30 @@ public class UserSearchRepositoryTest {
 			}
 			savePostByCnt(searchUser, i + 1);
 		}
+		User 가나다라 = createUserByNickname("가나다라");
+		User 나가 = createUserByNickname("나가");
+		User 나가라 = createUserByNickname("나가라");
+
+		User 다나가라 = createUserByNickname("다나가라");
+		createFollow(user, 다나가라);
+		User 나가지마라 = createUserByNickname("나가지마라");
+		createFollow(user, 나가지마라);
 
 		em.flush();
 		em.clear();
+	}
+
+	@DisplayName("나 를 포함하는 사용자 검색 테스트")
+	@Test
+	void searchUserContainingKeyword() {
+		String keyword = "나";
+		String nickname = "nickname";
+
+		List<SearchUserResponse> responses = userRepository.searchByKeyword(keyword, nickname);
+
+		for (SearchUserResponse res : responses) {
+			System.out.println("res = " + res.getNickname());
+		}
 	}
 
 	@DisplayName("키워드로 사용자 검색 테스트")


### PR DESCRIPTION
### ✅ PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [x] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- 사용자 검색 API : 사용자 검색시 키워드로 시작하는 닉네임을 가진 사용자만 검색되는 문제
- 연관 태그 검색 API : 키워드로 시작하는 연관 태그만 검색되는 문제
- 두 API 모두 키워드를 포함하는 응답으로 변경

### 📝 상세 내용(Describe your changes)
- 사용자 검색 기능은 검색한 사용자를 팔로잉하는지 닉네임이 키워드로 시작하는지, 문자 순서 기반으로 정렬
- 연관 태그 검색 기능은 태그와 키워드 일치하는지, 태그가 키워드로 시작하는지, 문자순서 기반으로 정렬

### 🔗 Issue Number or Link
- #63 