### PR TITLE
[FIX] : archivePost 조회순서 변경, archive 저장 해제 시 thumbnail 변경

### DIFF
--- a/src/main/java/com/backend/naildp/entity/ArchivePost.java
+++ b/src/main/java/com/backend/naildp/entity/ArchivePost.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ArchivePost {
+public class ArchivePost extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/backend/naildp/repository/ArchivePostRepository.java
+++ b/src/main/java/com/backend/naildp/repository/ArchivePostRepository.java
@@ -1,6 +1,7 @@
 package com.backend.naildp.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -36,7 +37,7 @@ public interface ArchivePostRepository extends JpaRepository<ArchivePost, Long> 
 	@Query("delete from ArchivePost ap where ap.post.id = :postId")
 	void deleteAllByPostId(@Param("postId") Long postId);
 
-	@Modifying(flushAutomatically = true, clearAutomatically = true)
-	@Query("delete from ArchivePost ap where ap.post.id = :postId and ap.archive.id in :archiveList")
-	void deleteAllByPostIdAndArchiveId(@Param("postId") Long postId, @Param("archiveList") List<Long> archiveList);
+	void deleteByPostIdAndArchiveId(@Param("postId") Long postId, @Param("archiveId") Long archiveId);
+
+	Optional<ArchivePost> findFirstByArchiveIdOrderByLastModifiedDateDesc(Long archiveId);
 }

--- a/src/main/java/com/backend/naildp/repository/PostRepository.java
+++ b/src/main/java/com/backend/naildp/repository/PostRepository.java
@@ -91,7 +91,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostSearchRep
 		+ " and (p.boundary = 'ALL'"
 		+ " or (p.boundary = 'FOLLOW' and p.user.nickname in :followingNickname)"
 		+ " or(p.boundary = 'NONE' and p.user.nickname = :myNickname)) "
-		+ " order by  p.createdDate desc ")
+		+ " order by  ap.lastModifiedDate desc ")
 	Slice<Post> findArchivePostsByFollow(@Param("myNickname") String myNickname,
 		@Param("archiveId") Long archiveId,
 		@Param("followingNickname") List<String> followingNickname,
@@ -104,7 +104,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostSearchRep
 		+ " and (p.boundary = 'ALL'"
 		+ " or (p.boundary = 'FOLLOW' and p.user.nickname in :followingNickname)"
 		+ " or(p.boundary = 'NONE' and p.user.nickname = :myNickname)) "
-		+ " order by  p.createdDate desc ")
+		+ " order by ap.lastModifiedDate desc ")
 	Slice<Post> findArchivePostsByIdAndFollow(@Param("id") Long id, @Param("myNickname") String myNickname,
 		@Param("archiveId") Long archiveId,
 		@Param("followingNickname") List<String> followingNickname,
@@ -120,7 +120,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostSearchRep
 		+ " and (p.boundary = 'ALL'"
 		+ " or (p.boundary = 'FOLLOW' and p.user.nickname in :followingNickname)"
 		+ " or(p.boundary = 'NONE' and p.user.nickname = :myNickname)) "
-		+ " order by  p.createdDate desc ")
+		+ " order by pl.lastModifiedDate desc ")
 	Slice<Post> findLikedArchivePostsByFollow(@Param("myNickname") String myNickname,
 		@Param("archiveId") Long archiveId,
 		@Param("followingNickname") List<String> followingNickname,
@@ -136,7 +136,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostSearchRep
 		+ " and (p.boundary = 'ALL'"
 		+ " or (p.boundary = 'FOLLOW' and p.user.nickname in :followingNickname)"
 		+ " or(p.boundary = 'NONE' and p.user.nickname = :myNickname)) "
-		+ " order by  p.createdDate desc ")
+		+ " order by  pl.lastModifiedDate desc ")
 	Slice<Post> findLikedArchivePostsByIdAndFollow(@Param("id") Long id, @Param("myNickname") String myNickname,
 		@Param("archiveId") Long archiveId,
 		@Param("followingNickname") List<String> followingNickname,

--- a/src/main/java/com/backend/naildp/service/ArchiveService.java
+++ b/src/main/java/com/backend/naildp/service/ArchiveService.java
@@ -315,10 +315,15 @@ public class ArchiveService {
 			if (archive.notEqualsNickname(nickname)) {
 				throw new CustomException("본인의 아카이브에만 접근할 수 있습니다.", ErrorCode.USER_MISMATCH);
 			}
-		});
 
-		archivePostRepository.deleteAllByPostIdAndArchiveId(unsaveRequestDto.getPostId(),
-			unsaveRequestDto.getArchiveId());
+			archivePostRepository.deleteByPostIdAndArchiveId(unsaveRequestDto.getPostId(), archiveId);
+
+			archivePostRepository.findFirstByArchiveIdOrderByLastModifiedDateDesc(archiveId)
+				.ifPresentOrElse(
+					archivePost -> archive.updateImgUrl(archivePost.getPost().getPhotos().get(0).getPhotoUrl()),
+					() -> archive.updateImgUrl(null)
+				);
+		});
 	}
 
 	@Transactional

--- a/src/test/java/com/backend/naildp/SecurityFilterTest.java
+++ b/src/test/java/com/backend/naildp/SecurityFilterTest.java
@@ -81,8 +81,8 @@ public class SecurityFilterTest {
 	@Test
 	@DisplayName("보호된 엔드포인트 테스트 - 인증 없이 접근 시")
 	public void securityTest2() throws Exception {
-		mockMvc.perform(get("/protected"))
-			.andExpect(status().isForbidden()) // 403
+		mockMvc.perform(get("/api/protected"))
+			.andExpect(status().isUnauthorized()) // 401
 			.andDo(print());
 	}
 
@@ -91,7 +91,7 @@ public class SecurityFilterTest {
 	@WithMockUser(username = "testuser", roles = {"USER"})
 	public void securityTest3() throws Exception {
 
-		mockMvc.perform(get("/protected"))
+		mockMvc.perform(get("/api/protected"))
 			.andExpect(status().isOk()) // 인증된 경우 200 OK 예상
 			.andDo(print());
 

--- a/src/test/java/com/backend/naildp/controller/CommentLikeControllerUnitTest.java
+++ b/src/test/java/com/backend/naildp/controller/CommentLikeControllerUnitTest.java
@@ -11,8 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -31,12 +29,6 @@ class CommentLikeControllerUnitTest {
 
 	@MockBean
 	CommentLikeService commentLikeService;
-
-	@MockBean
-	private OAuth2AuthorizedClientService authorizedClientService;
-
-	@MockBean
-	private ClientRegistrationRepository clientRegistrationRepository;
 
 	@DisplayName("댓글 좋아요 등록 예외 - 임시저장된 게시물에 접근했을 때")
 	@Test

--- a/src/test/java/com/backend/naildp/service/ArchiveServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/ArchiveServiceTest.java
@@ -368,7 +368,9 @@ class ArchiveServiceTest {
 		archiveService.unsaveFromArchive(nickname, unsaveRequestDto);
 
 		// Then
-		verify(archivePostRepository, times(1)).deleteAllByPostIdAndArchiveId(any(Long.class), anyList());
+		verify(archivePostRepository, times(2)).deleteByPostIdAndArchiveId(any(Long.class), any(Long.class));
+		verify(archivePostRepository, times(2)).findFirstByArchiveIdOrderByLastModifiedDateDesc(any(Long.class));
+
 	}
 
 	@Test

--- a/src/test/java/com/backend/naildp/service/FollowServiceUnitTest.java
+++ b/src/test/java/com/backend/naildp/service/FollowServiceUnitTest.java
@@ -54,15 +54,13 @@ class FollowServiceUnitTest {
 		String followingNickname = "following";
 		User followerUser = createUserByNickname(followerNickname);
 		User followingUser = createUserByNickname(followingNickname);
-		Follow follow = new Follow(followerUser, followingUser);
+		Follow follow = new Follow(followingUser, followerUser);
 
 		when(followRepository.findFollowByFollowerNicknameAndFollowingNickname(eq(followingNickname),
 			eq(followerNickname)))
 			.thenReturn(Optional.of(follow));
-
 		//when
-		Long followId = followService.followUser(followingNickname, followerNickname);
-
+		Long followId = followService.followUser(followerNickname, followingNickname);
 		//then
 		verify(followRepository).findFollowByFollowerNicknameAndFollowingNickname(followingNickname, followerNickname);
 		verify(userRepository, never()).findByNickname(anyString());
@@ -77,7 +75,7 @@ class FollowServiceUnitTest {
 		String followingNickname = "following";
 		User followerUser = createUserByNickname(followerNickname);
 		User followingUser = createUserByNickname(followingNickname);
-		Follow follow = new Follow(followerUser, followingUser);
+		Follow follow = new Follow(followingUser, followerUser);
 
 		when(followRepository.findFollowByFollowerNicknameAndFollowingNickname(eq(followingNickname),
 			eq(followerNickname)))
@@ -87,7 +85,7 @@ class FollowServiceUnitTest {
 		when(followRepository.saveAndFlush(any(Follow.class))).thenReturn(follow);
 
 		//when
-		Long followId = followService.followUser(followingNickname, followerNickname);
+		Long followId = followService.followUser(followerNickname, followingNickname);
 
 		//then
 		verify(followRepository).findFollowByFollowerNicknameAndFollowingNickname(followingNickname, followerNickname);

--- a/src/test/java/com/backend/naildp/service/PostCreateServiceTest.java
+++ b/src/test/java/com/backend/naildp/service/PostCreateServiceTest.java
@@ -8,12 +8,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -170,7 +168,6 @@ class PostCreateServiceTest {
 		Photo photo1 = new Photo(post, fileRequestDto1);
 		Photo photo2 = new Photo(post, fileRequestDto2);
 
-		given(userRepository.findByNickname(nickname)).willReturn(Optional.of(user));
 		given(postRepository.findById(postId)).willReturn(Optional.of(post));
 		given(tagRepository.findByName(anyString())).willAnswer(invocation -> {
 			String tagName = invocation.getArgument(0);
@@ -186,7 +183,6 @@ class PostCreateServiceTest {
 		postService.editPost(nickname, postRequestDto, files, postId);
 
 		// then
-		verify(userRepository, times(1)).findByNickname(nickname);
 		verify(postRepository, times(1)).findById(postId);
 		verify(tagPostRepository, times(1)).deleteAllByPostId(postId);
 		verify(tagRepository, times(2)).findByName(anyString());
@@ -226,7 +222,6 @@ class PostCreateServiceTest {
 		post.addPhoto(new Photo(post, new FileRequestDto("file1", 12345L, "fileUrl1")));
 		post.addPhoto(new Photo(post, new FileRequestDto("file2", 12345L, "fileUrl2")));
 
-		given(userRepository.findByNickname(nickname)).willReturn(Optional.of(user));
 		given(postRepository.findById(postId)).willReturn(Optional.of(post));
 
 		// then
@@ -275,7 +270,6 @@ class PostCreateServiceTest {
 		post.addTagPost(tagPost1);
 		post.addTagPost(tagPost2);
 
-		given(userRepository.findByNickname(nickname)).willReturn(Optional.of(user));
 		given(postRepository.findById(postId)).willReturn(Optional.of(post));
 		given(photoRepository.findAllByPostId(postId)).willReturn(List.of(photo1, photo2));
 


### PR DESCRIPTION

### ✅ PR Type

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- archivePost 조회순서 변경, archive 저장 해제 시 thumbnail 변경

### 📝 상세 내용(Describe your changes)
- archivePost 조회순서 변경(최근 생성한 게시물 순 -> 최근 저장한 순)
-  archive 저장 해제 시 thumbnail 변경되도록 수정
- test 오류 수정
### 🔗 Issue Number or Link
#42 