### PR TITLE
[FIX] : 프로필 사진 변경 안되는 문제 해결

### DIFF
--- a/src/main/java/com/backend/naildp/repository/ProfileRepository.java
+++ b/src/main/java/com/backend/naildp/repository/ProfileRepository.java
@@ -17,5 +17,9 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
 	Optional<Profile> findProfileByProfileUrl(String profileUrl);
 
+	@Query("SELECT p FROM Profile p JOIN UsersProfile up ON p.id = up.profile.id WHERE up.user.nickname = :nickname AND p.profileUrl = :profileUrl")
+	Optional<Profile> findProfileByNicknameAndProfileUrl(@Param("nickname") String nickname,
+		@Param("profileUrl") String profileUrl);
+
 	boolean existsProfileByProfileUrlStartsWith(String profileUrl);
 }

--- a/src/main/java/com/backend/naildp/service/UserInfoService.java
+++ b/src/main/java/com/backend/naildp/service/UserInfoService.java
@@ -110,7 +110,7 @@ public class UserInfoService {
 			.orElseThrow(() -> new CustomException("nickname 으로 회원을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
 
 		// 업로드하면 바로 해당 사진으로 썸네일 설정
-		Profile currentProfile = profileRepository.findProfileByProfileUrl(user.getThumbnailUrl())
+		Profile currentProfile = profileRepository.findProfileByNicknameAndProfileUrl(nickname, user.getThumbnailUrl())
 			.orElseThrow(() -> new CustomException("현재 프로필 이미지를 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
 
 		if (checkProfileType(currentProfile)) {
@@ -177,7 +177,7 @@ public class UserInfoService {
 		User user = userRepository.findByNickname(nickname)
 			.orElseThrow(() -> new CustomException("nickname 으로 회원을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
 
-		Profile currentProfile = profileRepository.findProfileByProfileUrl(user.getThumbnailUrl())
+		Profile currentProfile = profileRepository.findProfileByNicknameAndProfileUrl(nickname, user.getThumbnailUrl())
 			.orElseThrow(() -> new CustomException("현재 프로필 이미지를 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
 
 		Profile changingProfile = profileRepository.findProfileByProfileUrl(profileRequestDto.getProfileUrl())


### PR DESCRIPTION
### ✅ PR Type

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- 프로필 사진 변경 안되는 문제 해결

### 📝 상세 내용(Describe your changes)
- 변경 전
``` java
Optional<Profile> findProfileByProfileUrl(String profileUrl);
```

현재 프로필 사진을 profileUrl로 가져왔는데,  카카오 로그인 시 default 프로필 사진 URL이 같아 여러 값을 가져와 생긴 문제

- 변경 후
``` java
@Query("SELECT p FROM Profile p JOIN UsersProfile up ON p.id = up.profile.id 
WHERE up.user.nickname = :nickname AND p.profileUrl = :profileUrl")
Optional<Profile> findProfileByNicknameAndProfileUrl(@Param("nickname") String nickname,@Param("profileUrl") String profileUrl);
```
### 🔗 Issue Num
