### PR TITLE
[FIX]: kafka groupId를 서버마다 독립적으로 설정

### DIFF
--- a/src/main/java/com/backend/naildp/config/chat/KafkaConsumerConfig.java
+++ b/src/main/java/com/backend/naildp/config/chat/KafkaConsumerConfig.java
@@ -23,7 +23,8 @@ import com.backend.naildp.dto.chat.TempRoomSwitchDto;
 public class KafkaConsumerConfig {
 	@Value("${spring.kafka.bootstrap-servers}")
 	private String bootstrapAddress;
-	@Value("${spring.kafka.chat-consumer.group-id}")
+
+	@Value("${KAFKA_GROUP_ID:default-group}")
 	private String groupId;
 
 	@Bean


### PR DESCRIPTION

### ✅ PR Type

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

-  kafka consumerConfig 변경

### 📝 상세 내용(Describe your changes)
- 각각 서버마다 수신과 발신이 따로 작동하여 실시간으로 메시지가 안보내지는 문제
: kafka groupId를 서버마다 독립적으로 설정

### 🔗 Issue Number or Link
