### PR TITLE
[FIX] : Foryou게시물 조회 수정

### DIFF
--- a/src/main/java/com/backend/naildp/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/naildp/repository/PostRepositoryImpl.java
@@ -140,6 +140,7 @@ public class PostRepositoryImpl implements PostSearchRepository {
 			)
 			.orderBy(orderSpecifier, post.createdDate.desc())
 			.limit(pageable.getPageSize() + 1)
+			.distinct()
 			.fetch();
 
 		return new SliceImpl<>(posts, pageable, hasNext(posts, pageable.getPageSize()));


### PR DESCRIPTION
### ✅ PR Type

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [x] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- ForYou 게시물 조회 시 요청한 PageSize 만큼 조회하지 못하는 문제 해결

### 📝 상세 내용(Describe your changes)
- Post와 TagPost는 1대다 조인을 한다. 이때 Post 데이터는 TagPost에 맞춰 중복데이터가 생기고 원하는 크기의 데이터를 가져오지 못하는 현상이 발생
- `distinct()`를 사용해 Post중복 문제를 해결한다.

### 🔗 Issue Number or Link
- #116 