### PR TITLE
[REFACOTR] : 댓글 좋아요 API 에서 게시물 검증 로직 분리

### DIFF
--- a/src/main/java/com/backend/naildp/service/CommentLikeService.java
+++ b/src/main/java/com/backend/naildp/service/CommentLikeService.java
@@ -2,21 +2,18 @@ package com.backend.naildp.service;
 
 import java.util.Optional;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.backend.naildp.dto.postLike.PostLikeCountResponse;
 import com.backend.naildp.entity.Comment;
 import com.backend.naildp.entity.CommentLike;
-import com.backend.naildp.entity.Notification;
 import com.backend.naildp.entity.Post;
 import com.backend.naildp.entity.User;
 import com.backend.naildp.exception.CustomException;
 import com.backend.naildp.exception.ErrorCode;
 import com.backend.naildp.repository.CommentLikeRepository;
 import com.backend.naildp.repository.CommentRepository;
-import com.backend.naildp.repository.FollowRepository;
 import com.backend.naildp.repository.PostRepository;
 import com.backend.naildp.repository.UserRepository;
 
@@ -27,15 +24,18 @@ import lombok.RequiredArgsConstructor;
 public class CommentLikeService {
 
 	private final PostRepository postRepository;
-	private final FollowRepository followRepository;
 	private final UserRepository userRepository;
 	private final CommentRepository commentRepository;
 	private final CommentLikeRepository commentLikeRepository;
+	private final PostAccessValidator postAccessValidator;
 	private final NotificationManager notificationManager;
 
 	@Transactional
 	public Long likeComment(Long postId, Long commentId, String username) {
-		isAvailablePost(postId, username);
+		Post post = postRepository.findPostAndUser(postId)
+			.orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
+
+		postAccessValidator.isAvailablePost(post, username);
 
 		Optional<CommentLike> commentLikeOptional = commentLikeRepository.findCommentLikeByCommentIdAndUserNickname(
 			commentId, username);
@@ -59,7 +59,10 @@ public class CommentLikeService {
 
 	@Transactional
 	public void cancelCommentLike(Long postId, Long commentId, String username) {
-		isAvailablePost(postId, username);
+		Post post = postRepository.findPostAndUser(postId)
+			.orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
+
+		postAccessValidator.isAvailablePost(post, username);
 
 		commentLikeRepository.findCommentLikeByCommentIdAndUserNickname(commentId, username)
 			.ifPresent(commentLikeRepository::delete);
@@ -67,28 +70,12 @@ public class CommentLikeService {
 
 	@Transactional(readOnly = true)
 	public PostLikeCountResponse countCommentLikes(Long postId, Long commentId, String username) {
-		isAvailablePost(postId, username);
-
-		return new PostLikeCountResponse(commentLikeRepository.countAllByCommentId(commentId));
-	}
-
-	private void isAvailablePost(Long postId, String username) {
 		Post post = postRepository.findPostAndUser(postId)
 			.orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", ErrorCode.NOT_FOUND));
-		User postWriter = post.getUser();
 
-		if (post.isTempSaved()) {
-			throw new CustomException("임시저장한 게시물에는 댓글을 등록할 수 없습니다.", ErrorCode.NOT_FOUND);
-		}
+		postAccessValidator.isAvailablePost(post, username);
 
-		if (post.isClosed() && post.notWrittenBy(username)) {
-			throw new CustomException("비공개 게시물은 작성자만 접근할 수 있습니다.", ErrorCode.INVALID_BOUNDARY);
-		}
-
-		if (post.isOpenedForFollower() && !followRepository.existsByFollowerNicknameAndFollowing(username, postWriter)
-			&& post.notWrittenBy(username)) {
-			throw new CustomException("팔로우 공개 게시물은 팔로워와 작성자만 접근할 수 있습니다.", ErrorCode.INVALID_BOUNDARY);
-		}
+		return new PostLikeCountResponse(commentLikeRepository.countAllByCommentId(commentId));
 	}
 
 }

--- a/src/main/java/com/backend/naildp/service/PostAccessValidator.java
+++ b/src/main/java/com/backend/naildp/service/PostAccessValidator.java
@@ -1,0 +1,35 @@
+package com.backend.naildp.service;
+
+import org.springframework.stereotype.Component;
+
+import com.backend.naildp.entity.Post;
+import com.backend.naildp.entity.User;
+import com.backend.naildp.exception.CustomException;
+import com.backend.naildp.exception.ErrorCode;
+import com.backend.naildp.repository.FollowRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PostAccessValidator {
+
+	private final FollowRepository followRepository;
+
+	public void isAvailablePost(Post post, String username) {
+		User postWriter = post.getUser();
+
+		if (post.isTempSaved()) {
+			throw new CustomException("임시저장한 게시물에는 댓글을 등록할 수 없습니다.", ErrorCode.NOT_FOUND);
+		}
+
+		if (post.isClosed() && post.notWrittenBy(username)) {
+			throw new CustomException("비공개 게시물은 작성자만 접근할 수 있습니다.", ErrorCode.INVALID_BOUNDARY);
+		}
+
+		if (post.isOpenedForFollower() && !followRepository.existsByFollowerNicknameAndFollowing(username, postWriter)
+			&& post.notWrittenBy(username)) {
+			throw new CustomException("팔로우 공개 게시물은 팔로워와 작성자만 접근할 수 있습니다.", ErrorCode.INVALID_BOUNDARY);
+		}
+	}
+}


### PR DESCRIPTION
### ✅ PR Type

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [x] 테스트(Test)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other...

### 🖋️ 요약(Summary)

- 댓글 좋아요, 좋아요 취소, 좋아요 수 조회 API 의 공통 로직을 PostAccessValidator 로 분리
- 테스트 수정

### 📝 상세 내용(Describe your changes)
- 댓글 좋아요 기능과 게시물 접근 검증 로직이 같이 있어 읽기 좋은 코드가 아니라고 판단
- PostAccessValidator 에서 게시물의 임시저장, 비공개, 팔로우공개 인지 확인하는 로직을 진행한다.

### 🔗 Issue Number or Link
- #55 